### PR TITLE
Suppresses compiler warnings

### DIFF
--- a/lib/UIKit/TUIAttributedString.m
+++ b/lib/UIKit/TUIAttributedString.m
@@ -22,7 +22,7 @@
 
 + (TUIAttributedString *)stringWithString:(NSString *)string
 {
-	return [[[NSMutableAttributedString alloc] initWithString:string] autorelease];
+	return (TUIAttributedString *)[[[NSMutableAttributedString alloc] initWithString:string] autorelease];
 }
 
 @end


### PR DESCRIPTION
This commit suppresses compiler warnings in XCode 4. Some people don't agree on casting a return and there might be a reason Loren did this, but I like my compiles to be clean and see the green check mark.
