### PR TITLE
Adding header support for TUITableView sections

### DIFF
--- a/ExampleProject/ConcordeExample/ExampleSectionHeaderView.h
+++ b/ExampleProject/ConcordeExample/ExampleSectionHeaderView.h
@@ -1,0 +1,14 @@
+#import <Cocoa/Cocoa.h>
+
+#import "TUIKit.h"
+
+@interface ExampleSectionHeaderView : TUIView {
+  
+  TUITextRenderer * _labelRenderer;
+  
+}
+
+@property (readonly) TUITextRenderer  * labelRenderer;
+
+@end
+

--- a/ExampleProject/ConcordeExample/ExampleSectionHeaderView.m
+++ b/ExampleProject/ConcordeExample/ExampleSectionHeaderView.m
@@ -1,0 +1,45 @@
+#import "ExampleSectionHeaderView.h"
+
+@implementation ExampleSectionHeaderView
+
+@synthesize labelRenderer = _labelRenderer;
+
+/**
+ * Clean up
+ */
+-(void)dealloc {
+  [_labelRenderer release];
+  [super dealloc];
+}
+
+/**
+ * Initialize
+ */
+-(id)initWithFrame:(CGRect)frame {
+	if((self = [super initWithFrame:frame])) {
+		_labelRenderer = [[TUITextRenderer alloc] init];
+		self.textRenderers = [NSArray arrayWithObjects:_labelRenderer, nil];
+	}
+	return self;
+}
+
+/**
+ * Drawing
+ */
+-(void)drawRect:(CGRect)rect {
+  
+  CGContextRef g;
+  if((g = TUIGraphicsGetCurrentContext()) != nil){
+    
+    CGContextSetRGBFillColor(g, 0.8, 0.8, 0.8, 1);
+    CGContextFillRect(g, self.bounds);
+    
+    CGFloat labelHeight = 18;
+    self.labelRenderer.frame = CGRectMake(15, roundf((self.bounds.size.height - labelHeight) / 2.0), self.bounds.size.width - 30, labelHeight);
+    [self.labelRenderer draw];
+    
+  }
+  
+}
+
+@end

--- a/ExampleProject/ConcordeExample/ExampleView.m
+++ b/ExampleProject/ConcordeExample/ExampleView.m
@@ -16,6 +16,7 @@
 
 #import "ExampleView.h"
 #import "ExampleTableViewCell.h"
+#import "ExampleSectionHeaderView.h"
 
 #define TAB_HEIGHT 60
 
@@ -116,14 +117,28 @@
 	NSLog(@"selected tab %ld", index);
 }
 
+- (NSInteger)numberOfSectionsInTableView:(TUITableView *)tableView
+{
+	return 8;
+}
+
 - (NSInteger)tableView:(TUITableView *)table numberOfRowsInSection:(NSInteger)section
 {
-	return 200;
+	return 25;
 }
 
 - (CGFloat)tableView:(TUITableView *)tableView heightForRowAtIndexPath:(TUIFastIndexPath *)indexPath
 {
 	return 50.0;
+}
+
+-(TUIView *)tableView:(TUITableView *)tableView headerViewForSection:(NSInteger)section {
+  ExampleSectionHeaderView *view = [[ExampleSectionHeaderView alloc] initWithFrame:CGRectMake(0, 0, 100, 32)];
+  TUIAttributedString *title = [TUIAttributedString stringWithString:[NSString stringWithFormat:@"Example Section %d", section]];
+	title.color = [TUIColor blackColor];
+	title.font = exampleFont2;
+  view.labelRenderer.attributedString = title;
+  return [view autorelease];
 }
 
 - (TUITableViewCell *)tableView:(TUITableView *)tableView cellForRowAtIndexPath:(TUIFastIndexPath *)indexPath

--- a/ExampleProject/Example.xcodeproj/project.pbxproj
+++ b/ExampleProject/Example.xcodeproj/project.pbxproj
@@ -65,6 +65,7 @@
 		5ED56727139DC35100031CDF /* TUIView.m in Sources */ = {isa = PBXBuildFile; fileRef = 5ED566F2139DC35100031CDF /* TUIView.m */; };
 		5ED56728139DC35100031CDF /* TUIViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 5ED566F4139DC35100031CDF /* TUIViewController.m */; };
 		5ED56736139DC35800031CDF /* CoreText+Additions.m in Sources */ = {isa = PBXBuildFile; fileRef = 5ED56732139DC35800031CDF /* CoreText+Additions.m */; };
+		D3CE671313C6646B00D47B2D /* ExampleSectionHeaderView.m in Sources */ = {isa = PBXBuildFile; fileRef = D3CE671213C6646B00D47B2D /* ExampleSectionHeaderView.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -177,6 +178,8 @@
 		5ED566F5139DC35100031CDF /* TUIViewNSViewContainer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TUIViewNSViewContainer.h; sourceTree = "<group>"; };
 		5ED56731139DC35800031CDF /* CoreText+Additions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "CoreText+Additions.h"; path = "../Support/CoreText+Additions.h"; sourceTree = "<group>"; };
 		5ED56732139DC35800031CDF /* CoreText+Additions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "CoreText+Additions.m"; path = "../Support/CoreText+Additions.m"; sourceTree = "<group>"; };
+		D3CE671113C6646B00D47B2D /* ExampleSectionHeaderView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ExampleSectionHeaderView.h; sourceTree = "<group>"; };
+		D3CE671213C6646B00D47B2D /* ExampleSectionHeaderView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ExampleSectionHeaderView.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -256,6 +259,8 @@
 				5C90DB9C13A7C08D00ECDD14 /* ExampleTabBar.m */,
 				5C55D83513A66BD5000ED768 /* ExampleTableViewCell.h */,
 				5C55D83613A66BD5000ED768 /* ExampleTableViewCell.m */,
+				D3CE671113C6646B00D47B2D /* ExampleSectionHeaderView.h */,
+				D3CE671213C6646B00D47B2D /* ExampleSectionHeaderView.m */,
 				5ED5668C139DC30300031CDF /* MainMenu.xib */,
 				5ED5667E139DC30300031CDF /* Supporting Files */,
 			);
@@ -477,6 +482,7 @@
 				5C55D83413A667A0000ED768 /* ExampleView.m in Sources */,
 				5C55D83713A66BD5000ED768 /* ExampleTableViewCell.m in Sources */,
 				5C90DB9D13A7C08E00ECDD14 /* ExampleTabBar.m in Sources */,
+				D3CE671313C6646B00D47B2D /* ExampleSectionHeaderView.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/lib/UIKit/TUIFastIndexPath.h
+++ b/lib/UIKit/TUIFastIndexPath.h
@@ -21,6 +21,9 @@
 #define TUIFastIndexPath_DANGEROUS_ISEQUAL 1
 #endif
 
+#define TUIFastIndexPathFromNSIndexPath(indexPath)  (((indexPath) != nil) ? [TUIFastIndexPath indexPathForRow:(indexPath).row inSection:(indexPath).section] : nil)
+#define NSIndexPathFromTUIFastIndexPath(indexPath)  (((indexPath) != nil) ? [NSIndexPath indexPathForRow:(indexPath).row inSection:(indexPath).section] : nil)
+
 /**
  Note TUITableView uses this extensively, if you use want to use NSIndexPath to talk to table views you should turn TUIFastIndexPath_DANGEROUS_ISEQUAL to 0
  */

--- a/lib/UIKit/TUITableView.h
+++ b/lib/UIKit/TUITableView.h
@@ -46,34 +46,36 @@ typedef enum {
 
 @end
 
-@interface TUITableView : TUIScrollView
-{
-	TUITableViewStyle				 _style;
-	id <TUITableViewDataSource>	 _dataSource; // weak
-	NSArray							*_sectionInfo;
-
-	TUIView						*_pullDownView;
-
-	CGSize							_lastSize;
-	CGFloat							_contentHeight;
-	
-	NSMutableDictionary				*_visibleItems;
-	NSMutableDictionary				*_reusableTableCells;
-	
-	TUIFastIndexPath				*_selectedIndexPath;
-	TUIFastIndexPath				*_indexPathShouldBeFirstResponder;
-	NSInteger						_futureMakeFirstResponderToken;
-	TUIFastIndexPath				*_keepVisibleIndexPathForReload;
-	CGFloat							_relativeOffsetForReload;
-	
-	struct {
-		unsigned int forceSaveScrollPosition:1;
-		unsigned int derepeaterEnabled:1;
-		unsigned int layoutSubviewsReentrancyGuard:1;
-		unsigned int didFirstLayout:1;
-		unsigned int dataSourceNumberOfSectionsInTableView:1;
-		unsigned int delegateTableViewWillDisplayCellForRowAtIndexPath:1;
-	} _tableFlags;
+@interface TUITableView : TUIScrollView {
+  
+  TUITableViewStyle             _style;
+  id <TUITableViewDataSource>	  _dataSource; // weak
+  NSArray							        * _sectionInfo;
+  
+  TUIView                     * _pullDownView;
+  
+  CGSize                        _lastSize;
+  CGFloat                       _contentHeight;
+  
+  NSMutableIndexSet           * _visibleSectionHeaders;
+  NSMutableDictionary         * _visibleItems;
+  NSMutableDictionary         * _reusableTableCells;
+  
+  TUIFastIndexPath            * _selectedIndexPath;
+  TUIFastIndexPath            * _indexPathShouldBeFirstResponder;
+  NSInteger                     _futureMakeFirstResponderToken;
+  TUIFastIndexPath            * _keepVisibleIndexPathForReload;
+  CGFloat                       _relativeOffsetForReload;
+  
+  struct {
+    unsigned int forceSaveScrollPosition:1;
+    unsigned int derepeaterEnabled:1;
+    unsigned int layoutSubviewsReentrancyGuard:1;
+    unsigned int didFirstLayout:1;
+    unsigned int dataSourceNumberOfSectionsInTableView:1;
+    unsigned int delegateTableViewWillDisplayCellForRowAtIndexPath:1;
+  } _tableFlags;
+  
 }
 
 - (id)initWithFrame:(CGRect)frame style:(TUITableViewStyle)style;                // must specify style at creation. -initWithFrame: calls this with UITableViewStylePlain
@@ -91,8 +93,11 @@ typedef enum {
 - (NSInteger)numberOfSections;
 - (NSInteger)numberOfRowsInSection:(NSInteger)section;
 
+- (CGRect)rectForHeaderOfSection:(NSInteger)section;
 - (CGRect)rectForRowAtIndexPath:(TUIFastIndexPath *)indexPath;
 
+- (NSIndexSet *)indexesOfSectionsInRect:(CGRect)rect;
+- (NSIndexSet *)indexesOfSectionHeadersInRect:(CGRect)rect;
 - (TUIFastIndexPath *)indexPathForCell:(TUITableViewCell *)cell;                      // returns nil if cell is not visible
 - (NSArray *)indexPathsForRowsInRect:(CGRect)rect;                              // returns nil if rect not valid 
 
@@ -133,6 +138,8 @@ typedef enum {
 - (TUITableViewCell *)tableView:(TUITableView *)tableView cellForRowAtIndexPath:(TUIFastIndexPath *)indexPath;
 
 @optional
+
+- (TUITableViewCell *)tableView:(TUITableView *)tableView headerViewForSection:(NSInteger)section;
 
 /**
  Default is 1 if not implemented

--- a/lib/UIKit/TUITableView.h
+++ b/lib/UIKit/TUITableView.h
@@ -42,6 +42,7 @@ typedef enum {
 
 - (void)tableView:(TUITableView *)tableView willDisplayCell:(TUITableViewCell *)cell forRowAtIndexPath:(TUIFastIndexPath *)indexPath; // not implemented yet
 - (void)tableView:(TUITableView *)tableView didSelectRowAtIndexPath:(TUIFastIndexPath *)indexPath; // happens on mouse down
+- (void)tableView:(TUITableView *)tableView didDeselectRowAtIndexPath:(TUIFastIndexPath *)indexPath;
 - (void)tableView:(TUITableView *)tableView didClickRowAtIndexPath:(TUIFastIndexPath *)indexPath withEvent:(NSEvent *)event; // happens on mouse up (can look at clickCount)
 
 @end
@@ -67,6 +68,8 @@ typedef enum {
   TUIFastIndexPath            * _keepVisibleIndexPathForReload;
   CGFloat                       _relativeOffsetForReload;
   
+  BOOL                          _animateSelectionChanges;
+  
   struct {
     unsigned int forceSaveScrollPosition:1;
     unsigned int derepeaterEnabled:1;
@@ -80,8 +83,10 @@ typedef enum {
 
 - (id)initWithFrame:(CGRect)frame style:(TUITableViewStyle)style;                // must specify style at creation. -initWithFrame: calls this with UITableViewStylePlain
 
-@property (nonatomic,assign) id <TUITableViewDataSource> dataSource;
-@property (nonatomic,assign) id <TUITableViewDelegate>   delegate;
+@property (nonatomic,assign) id <TUITableViewDataSource>  dataSource;
+@property (nonatomic,assign) id <TUITableViewDelegate>    delegate;
+
+@property (readwrite, assign) BOOL                        animateSelectionChanges;
 
 - (void)reloadData;
 

--- a/lib/UIKit/TUITableView.m
+++ b/lib/UIKit/TUITableView.m
@@ -22,16 +22,19 @@ typedef struct {
 	CGFloat height;
 } TUITableViewRowInfo;
 
-@interface TUITableViewSection : NSObject
-{
-	TUITableView *_tableView; // weak
-	NSInteger sectionIndex;
-	NSUInteger numberOfRows;
-	CGFloat sectionHeight;
-	CGFloat sectionOffset;
-	TUITableViewRowInfo *rowInfo;
+@interface TUITableViewSection : NSObject {
+  
+  TUITableView        * _tableView;   // weak
+  TUIView             * _headerView;  // Not reusable (similar to UITableView)
+  NSInteger             sectionIndex;
+  NSUInteger            numberOfRows;
+  CGFloat               sectionHeight;
+  CGFloat               sectionOffset;
+  TUITableViewRowInfo * rowInfo;
+  
 }
 
+@property (readonly) TUIView        * headerView;
 @property (nonatomic, assign) CGFloat sectionOffset;
 
 @end
@@ -40,10 +43,8 @@ typedef struct {
 
 @synthesize sectionOffset;
 
-- (id)initWithNumberOfRows:(NSUInteger)n sectionIndex:(NSInteger)s tableView:(TUITableView *)t
-{
-	if((self = [super init]))
-	{
+-(id)initWithNumberOfRows:(NSUInteger)n sectionIndex:(NSInteger)s tableView:(TUITableView *)t {
+	if((self = [super init])){
 		_tableView = t;
 		sectionIndex = s;
 		numberOfRows = n;
@@ -52,56 +53,77 @@ typedef struct {
 	return self;
 }
 
-- (void)dealloc
-{
-	free(rowInfo);
+-(void)dealloc {
+	if(rowInfo) free(rowInfo);
+	[_headerView release];
 	[super dealloc];
 }
 
-- (NSUInteger)numberOfRows
-{
+-(NSUInteger)numberOfRows {
 	return numberOfRows;
 }
 
-- (void)_setupRowHeights
-{
-	int i;
+-(void)_setupRowHeights {
 	sectionHeight = 0.0;
-	for(i = 0; i < numberOfRows; ++i) {
+	
+  TUIView *header;
+  if((header = self.headerView) != nil){
+    sectionHeight += roundf(header.frame.size.height);
+  }
+  
+	for(int i = 0; i < numberOfRows; ++i) {
 		CGFloat h = roundf([_tableView.delegate tableView:_tableView heightForRowAtIndexPath:[TUIFastIndexPath indexPathForRow:i inSection:sectionIndex]]);
 		rowInfo[i].offset = sectionHeight;
 		rowInfo[i].height = h;
 		sectionHeight += h;
 	}
+	
 }
 
-- (CGFloat)rowHeight:(NSInteger)i
-{
-	if(i >= 0 && i < numberOfRows)
+-(CGFloat)rowHeight:(NSInteger)i {
+	if(i >= 0 && i < numberOfRows){
 		return rowInfo[i].height;
+	}
 	return 0.0;
 }
 
-- (CGFloat)sectionRowOffset:(NSInteger)i
-{
-	if(i >= 0 && i < numberOfRows)
+-(CGFloat)sectionRowOffset:(NSInteger)i {
+	if(i >= 0 && i < numberOfRows){
 		return rowInfo[i].offset;
+	}
 	return 0.0;
 }
 
-- (CGFloat)tableRowOffset:(NSInteger)i
-{
+-(CGFloat)tableRowOffset:(NSInteger)i {
 	return sectionOffset + [self sectionRowOffset:i];
 }
 
-- (CGFloat)sectionHeight
-{
+-(CGFloat)sectionHeight {
 	return sectionHeight;
 }
 
+-(CGFloat)headerHeight {
+	return (self.headerView != nil) ? self.headerView.frame.size.height : 0;
+}
+
+/**
+ * @brief Obtain the section header view.
+ * 
+ * The section header view is created lazily via the data source when this
+ * method is first called.
+ * 
+ * @return section header view
+ */
+-(TUIView *)headerView {
+  if(_headerView == nil){
+    if(_tableView.dataSource != nil && [_tableView.dataSource respondsToSelector:@selector(tableView:headerViewForSection:)]){
+      _headerView = [[_tableView.dataSource tableView:_tableView headerViewForSection:sectionIndex] retain];
+    }
+  }
+  return _headerView;
+}
+
 @end
-
-
 
 @interface TUITableView (Private)
 - (void)_updateDerepeaterViews;
@@ -116,6 +138,7 @@ typedef struct {
 	if((self = [super initWithFrame:frame])) {
 		_style = style;
 		_reusableTableCells = [[NSMutableDictionary alloc] init];
+		_visibleSectionHeaders = [[NSMutableIndexSet alloc] init];
 		_visibleItems = [[NSMutableDictionary alloc] init];
 	}
 	return self;
@@ -129,6 +152,7 @@ typedef struct {
 - (void)dealloc
 {
 	[_sectionInfo release];
+	[_visibleSectionHeaders release];
 	[_visibleItems release];
 	[_reusableTableCells release];
 	[_selectedIndexPath release];
@@ -170,6 +194,17 @@ typedef struct {
 	return [[_sectionInfo objectAtIndex:section] numberOfRows];
 }
 
+-(CGRect)rectForHeaderOfSection:(NSInteger)section {
+	if(section >= 0 && section < [_sectionInfo count]){
+		TUITableViewSection *s = [_sectionInfo objectAtIndex:section];
+		CGFloat offset = [s sectionOffset];
+		CGFloat height = [s headerHeight];
+		CGFloat y = _contentHeight - offset - height;
+		return CGRectMake(0, y, self.bounds.size.width, height);
+	}
+	return CGRectZero;
+}
+
 - (CGRect)rectForRowAtIndexPath:(TUIFastIndexPath *)indexPath
 {
 	NSInteger section = indexPath.section;
@@ -184,16 +219,13 @@ typedef struct {
 	return CGRectZero;
 }
 
-
-
-
-
-
 - (NSArray *)_freshSectionInfo
 {
 	NSInteger numberOfSections = 1;
-	if(_tableFlags.dataSourceNumberOfSectionsInTableView)
+	
+	if(_tableFlags.dataSourceNumberOfSectionsInTableView){
 		numberOfSections = [_dataSource numberOfSectionsInTableView:self];
+	}
 	
 	NSMutableArray *sections = [NSMutableArray arrayWithCapacity:numberOfSections];
 	
@@ -289,6 +321,58 @@ static NSInteger SortCells(TUITableViewCell *a, TUITableViewCell *b, void *ctx)
 			return i;
 	}
 	return nil;
+}
+
+/**
+ * @brief Obtain the indexes of sections which intersect @p rect.
+ * 
+ * @param rect the rect
+ * @return intersecting sections
+ */
+-(NSIndexSet *)indexesOfSectionsInRect:(CGRect)rect {
+  NSMutableIndexSet *indexes = [[NSMutableIndexSet alloc] init];
+  BOOL foundAny = FALSE;
+  
+	for(int i = 0; i < [_sectionInfo count]; i++) {
+	  TUITableViewSection *section = [_sectionInfo objectAtIndex:i];
+		NSInteger numberOfRows = [section numberOfRows];
+    if(CGRectIntersectsRect(CGRectMake(0, section.sectionOffset, self.bounds.size.width, section.sectionHeight), rect)){
+      [indexes addIndex:i];
+      foundAny = TRUE;
+    }else if(foundAny){
+      // we've passed the area that contains headers, so we don't need
+      // to keep looking for visible frames
+      break;
+    }
+	}
+	
+  return [indexes autorelease];
+}
+
+/**
+ * @brief Obtain the indexes of sections whose header views intersect @p rect.
+ * 
+ * @param rect the rect
+ * @return intersecting sections
+ */
+-(NSIndexSet *)indexesOfSectionHeadersInRect:(CGRect)rect {
+  NSMutableIndexSet *indexes = [[NSMutableIndexSet alloc] init];
+  BOOL foundAny = FALSE;
+  
+	for(int i = 0; i < [_sectionInfo count]; i++) {
+	  TUITableViewSection *section = [_sectionInfo objectAtIndex:i];
+		NSInteger numberOfRows = [section numberOfRows];
+    if(CGRectIntersectsRect(CGRectMake(0, section.sectionOffset, self.bounds.size.width, section.headerHeight), rect)){
+      [indexes addIndex:i];
+      foundAny = TRUE;
+    }else if(foundAny){
+      // we've passed the area that contains headers, so we don't need
+      // to keep looking for visible frames
+      break;
+    }
+	}
+	
+  return [indexes autorelease];
 }
 
 - (NSArray *)indexPathsForRowsInRect:(CGRect)rect
@@ -400,8 +484,57 @@ static NSInteger SortCells(TUITableViewCell *a, TUITableViewCell *b, void *ctx)
 	return NO; // just need to do the recycling
 }
 
+/**
+ * @brief Layout header views for sections which have one.
+ */
+-(void)_layoutSectionHeaders:(BOOL)visibleHeadersNeedRelayout {
+  
+  if(visibleHeadersNeedRelayout){
+    if(_visibleSectionHeaders != nil){
+      [_visibleSectionHeaders enumerateIndexesUsingBlock:^(NSUInteger index, BOOL *stop) {
+        TUITableViewSection *section = [_sectionInfo objectAtIndex:index];
+        if(section.headerView != nil){
+          section.headerView.frame = [self rectForHeaderOfSection:index];
+          [section.headerView setNeedsLayout];
+        }
+      }];
+    }
+  }
+  
+	CGRect visible = [self visibleRect];
+	
+	NSIndexSet *oldIndexes = _visibleSectionHeaders;
+	NSIndexSet *newIndexes = [self indexesOfSectionHeadersInRect:visible];
+	
+	NSMutableIndexSet *toRemove = [[oldIndexes mutableCopy] autorelease];
+	[toRemove removeIndexes:newIndexes];
+	NSMutableIndexSet *toAdd = [[newIndexes mutableCopy] autorelease];
+	[toAdd removeIndexes:oldIndexes];
+	
+	// remove offscreen headers
+	[toRemove enumerateIndexesUsingBlock:^(NSUInteger index, BOOL *stop) {
+    TUITableViewSection *section = [_sectionInfo objectAtIndex:index];
+    if(section.headerView != nil){
+      [section.headerView removeFromSuperview];
+    }
+		[_visibleSectionHeaders removeIndex:index];
+	}];
+	
+	// add new headeres
+	[toAdd enumerateIndexesUsingBlock:^(NSUInteger index, BOOL *stop) {
+    TUITableViewSection *section = [_sectionInfo objectAtIndex:index];
+    if(section.headerView != nil){
+      section.headerView.frame = [self rectForHeaderOfSection:index];
+      [self addSubview:section.headerView];
+    }
+		[_visibleSectionHeaders addIndex:index];
+	}];
+  
+}
+
 - (void)_layoutCells:(BOOL)visibleCellsNeedRelayout
 {
+  
 	if(visibleCellsNeedRelayout) {
 		// update remaining visible cells if needed
 		for(TUIFastIndexPath *i in _visibleItems) {
@@ -525,6 +658,7 @@ static NSInteger SortCells(TUITableViewCell *a, TUITableViewCell *b, void *ctx)
 			
 			BOOL visibleCellsNeedRelayout = [self _preLayoutCells];
 			[super layoutSubviews]; // this will munge with the contentOffset
+			[self _layoutSectionHeaders:visibleCellsNeedRelayout];
 			[self _layoutCells:visibleCellsNeedRelayout];
 			
 			if(_tableFlags.derepeaterEnabled)

--- a/lib/UIKit/TUITableView.m
+++ b/lib/UIKit/TUITableView.m
@@ -480,10 +480,12 @@ static NSInteger SortCells(TUITableViewCell *a, TUITableViewCell *b, void *ctx)
   if(visibleHeadersNeedRelayout){
     if(_visibleSectionHeaders != nil){
       [_visibleSectionHeaders enumerateIndexesUsingBlock:^(NSUInteger index, BOOL *stop) {
-        TUITableViewSection *section = [_sectionInfo objectAtIndex:index];
-        if(section.headerView != nil){
-          section.headerView.frame = [self rectForHeaderOfSection:index];
-          [section.headerView setNeedsLayout];
+        if(index >= 0 && index < [_sectionInfo count]){
+          TUITableViewSection *section = [_sectionInfo objectAtIndex:index];
+          if(section.headerView != nil){
+            section.headerView.frame = [self rectForHeaderOfSection:index];
+            [section.headerView setNeedsLayout];
+          }
         }
       }];
     }
@@ -501,20 +503,24 @@ static NSInteger SortCells(TUITableViewCell *a, TUITableViewCell *b, void *ctx)
 	
 	// remove offscreen headers
 	[toRemove enumerateIndexesUsingBlock:^(NSUInteger index, BOOL *stop) {
-    TUITableViewSection *section = [_sectionInfo objectAtIndex:index];
-    if(section.headerView != nil){
-      [section.headerView removeFromSuperview];
+    if(index >= 0 && index < [_sectionInfo count]){
+      TUITableViewSection *section = [_sectionInfo objectAtIndex:index];
+      if(section.headerView != nil){
+        [section.headerView removeFromSuperview];
+      }
     }
-		[_visibleSectionHeaders removeIndex:index];
+    [_visibleSectionHeaders removeIndex:index];
 	}];
 	
 	// add new headers
 	[toAdd enumerateIndexesUsingBlock:^(NSUInteger index, BOOL *stop) {
-    TUITableViewSection *section = [_sectionInfo objectAtIndex:index];
-    if(section.headerView != nil){
-      section.headerView.frame = [self rectForHeaderOfSection:index];
-      [section.headerView setNeedsLayout];
-      [self addSubview:section.headerView];
+    if(index >= 0 && index < [_sectionInfo count]){
+      TUITableViewSection *section = [_sectionInfo objectAtIndex:index];
+      if(section.headerView != nil){
+        section.headerView.frame = [self rectForHeaderOfSection:index];
+        [section.headerView setNeedsLayout];
+        [self addSubview:section.headerView];
+      }
     }
 		[_visibleSectionHeaders addIndex:index];
 	}];

--- a/lib/UIKit/TUITableView.m
+++ b/lib/UIKit/TUITableView.m
@@ -34,14 +34,16 @@ typedef struct {
   
 }
 
-@property (readonly) TUIView        * headerView;
-@property (nonatomic, assign) CGFloat sectionOffset;
+@property (readonly) TUIView          * headerView;
+@property (nonatomic, assign) CGFloat   sectionOffset;
+@property (readonly) NSInteger          sectionIndex;
 
 @end
 
 @implementation TUITableViewSection
 
 @synthesize sectionOffset;
+@synthesize sectionIndex;
 
 -(id)initWithNumberOfRows:(NSUInteger)n sectionIndex:(NSInteger)s tableView:(TUITableView *)t {
 	if((self = [super init])){
@@ -335,9 +337,7 @@ static NSInteger SortCells(TUITableViewCell *a, TUITableViewCell *b, void *ctx)
   NSMutableIndexSet *indexes = [[NSMutableIndexSet alloc] init];
   
 	for(int i = 0; i < [_sectionInfo count]; i++) {
-	  TUITableViewSection *section = [_sectionInfo objectAtIndex:[_sectionInfo count] - i - 1];
-		NSInteger numberOfRows = [section numberOfRows];
-    if(CGRectIntersectsRect(CGRectMake(0, section.sectionOffset, self.bounds.size.width, section.sectionHeight), rect)){
+    if(CGRectIntersectsRect([self rectForHeaderOfSection:i], rect)){
       [indexes addIndex:i];
     }
 	}
@@ -355,9 +355,7 @@ static NSInteger SortCells(TUITableViewCell *a, TUITableViewCell *b, void *ctx)
   NSMutableIndexSet *indexes = [[NSMutableIndexSet alloc] init];
   
 	for(int i = 0; i < [_sectionInfo count]; i++) {
-	  TUITableViewSection *section = [_sectionInfo objectAtIndex:[_sectionInfo count] - i - 1];
-		NSInteger numberOfRows = [section numberOfRows];
-    if(CGRectIntersectsRect(CGRectMake(0, section.sectionOffset, self.bounds.size.width, section.headerHeight), rect)){
+    if(CGRectIntersectsRect([self rectForHeaderOfSection:i], rect)){
       [indexes addIndex:i];
     }
 	}

--- a/lib/UIKit/TUITableView.m
+++ b/lib/UIKit/TUITableView.m
@@ -331,18 +331,12 @@ static NSInteger SortCells(TUITableViewCell *a, TUITableViewCell *b, void *ctx)
  */
 -(NSIndexSet *)indexesOfSectionsInRect:(CGRect)rect {
   NSMutableIndexSet *indexes = [[NSMutableIndexSet alloc] init];
-  BOOL foundAny = FALSE;
   
 	for(int i = 0; i < [_sectionInfo count]; i++) {
-	  TUITableViewSection *section = [_sectionInfo objectAtIndex:i];
+	  TUITableViewSection *section = [_sectionInfo objectAtIndex:[_sectionInfo count] - i - 1];
 		NSInteger numberOfRows = [section numberOfRows];
     if(CGRectIntersectsRect(CGRectMake(0, section.sectionOffset, self.bounds.size.width, section.sectionHeight), rect)){
       [indexes addIndex:i];
-      foundAny = TRUE;
-    }else if(foundAny){
-      // we've passed the area that contains headers, so we don't need
-      // to keep looking for visible frames
-      break;
     }
 	}
 	
@@ -357,18 +351,12 @@ static NSInteger SortCells(TUITableViewCell *a, TUITableViewCell *b, void *ctx)
  */
 -(NSIndexSet *)indexesOfSectionHeadersInRect:(CGRect)rect {
   NSMutableIndexSet *indexes = [[NSMutableIndexSet alloc] init];
-  BOOL foundAny = FALSE;
   
 	for(int i = 0; i < [_sectionInfo count]; i++) {
-	  TUITableViewSection *section = [_sectionInfo objectAtIndex:i];
+	  TUITableViewSection *section = [_sectionInfo objectAtIndex:[_sectionInfo count] - i - 1];
 		NSInteger numberOfRows = [section numberOfRows];
     if(CGRectIntersectsRect(CGRectMake(0, section.sectionOffset, self.bounds.size.width, section.headerHeight), rect)){
       [indexes addIndex:i];
-      foundAny = TRUE;
-    }else if(foundAny){
-      // we've passed the area that contains headers, so we don't need
-      // to keep looking for visible frames
-      break;
     }
 	}
 	
@@ -520,11 +508,12 @@ static NSInteger SortCells(TUITableViewCell *a, TUITableViewCell *b, void *ctx)
 		[_visibleSectionHeaders removeIndex:index];
 	}];
 	
-	// add new headeres
+	// add new headers
 	[toAdd enumerateIndexesUsingBlock:^(NSUInteger index, BOOL *stop) {
     TUITableViewSection *section = [_sectionInfo objectAtIndex:index];
     if(section.headerView != nil){
       section.headerView.frame = [self rectForHeaderOfSection:index];
+      [section.headerView setNeedsLayout];
       [self addSubview:section.headerView];
     }
 		[_visibleSectionHeaders addIndex:index];

--- a/lib/UIKit/TUITableViewCell.m
+++ b/lib/UIKit/TUITableViewCell.m
@@ -75,10 +75,7 @@
 - (void)mouseDown:(NSEvent *)event
 {
 	TUITableView *tableView = self.tableView;
-	[tableView selectRowAtIndexPath:self.indexPath animated:YES scrollPosition:TUITableViewScrollPositionNone];
-	if([tableView.delegate respondsToSelector:@selector(tableView:didSelectRowAtIndexPath:)])
-		[tableView.delegate tableView:tableView didSelectRowAtIndexPath:self.indexPath];
-	
+	[tableView selectRowAtIndexPath:self.indexPath animated:tableView.animateSelectionChanges scrollPosition:TUITableViewScrollPositionNone];
 	[super mouseDown:event]; // may make the text renderer first responder, so we want to do the selection before this
 	_tableViewCellFlags.highlighted = 1;
 	[self setNeedsDisplay];
@@ -92,8 +89,9 @@
 	
 	if([self eventInside:event]) {
 		TUITableView *tableView = self.tableView;
-		if([tableView.delegate respondsToSelector:@selector(tableView:didClickRowAtIndexPath:withEvent:)])
+		if([tableView.delegate respondsToSelector:@selector(tableView:didClickRowAtIndexPath:withEvent:)]){
 			[tableView.delegate tableView:tableView didClickRowAtIndexPath:self.indexPath withEvent:event];
+		}
 	}
 }
 


### PR DESCRIPTION
UITableView will display a header view for sections when its data source returns a view for the new delegate method tableView:headerViewForSection:.  The header view is a plain old TUIView and is not reusable (stored in section info).  The height of the header view is not adjusted by the table view and its height determines the height of the section header.

I've also changed the way did select delegate methods are triggered (they're taken out of the cell, since they really belong to the table) so that changing the selection either by clicking or via the arrow keys (or some other programmatic method) now notifies the delegate.  Previously, changing the selection by arrow keys did not actually notify the delegate the selection had changed.

I've also added .animateSelectionChanges to TUITableView which can be set FALSE to cause the table not to animation selection changes.  There's probably a more elegant way to do this...

The example project has been updated to reflect these changes.
