### PR TITLE
A bunch of text rendering improvements

### DIFF
--- a/lib/Support/CoreText+Additions.h
+++ b/lib/Support/CoreText+Additions.h
@@ -20,9 +20,15 @@
 #import <CoreText/CoreText.h>
 #endif
 
+typedef enum {
+	AB_CTLineRectAggregationTypeInline = 0,
+	AB_CTLineRectAggregationTypeBlock,
+} AB_CTLineRectAggregationType;
+
 extern CGSize AB_CTLineGetSize(CTLineRef line);
 extern CGSize AB_CTFrameGetSize(CTFrameRef frame);
 extern CGFloat AB_CTFrameGetHeight(CTFrameRef frame);
 extern CFIndex AB_CTFrameGetStringIndexForPosition(CTFrameRef frame, CGPoint p);
 
 extern void AB_CTFrameGetRectsForRange(CTFrameRef frame, CFRange range, CGRect rects[], CFIndex *rectCount);
+extern void AB_CTFrameGetRectsForRangeWithAggregationType(CTFrameRef frame, CFRange range, AB_CTLineRectAggregationType aggregationType, CGRect rects[], CFIndex *rectCount);

--- a/lib/UIKit/TUIAttributedString.h
+++ b/lib/UIKit/TUIAttributedString.h
@@ -16,6 +16,9 @@
 
 #import <Foundation/Foundation.h>
 
+extern NSString * const TUIAttributedStringBackgroundColorAttributeName;
+extern NSString * const TUIAttributedStringBackgroundFillStyleName;
+
 @class TUIFont;
 @class TUIColor;
 
@@ -41,6 +44,11 @@ typedef enum {
 	TUITextAlignmentJustified,
 } TUITextAlignment;
 
+typedef enum {
+	TUIBackgroundFillStyleInline = 0,
+	TUIBackgroundFillStyleBlock,
+} TUIBackgroundFillStyle;
+
 @interface TUIAttributedString : NSMutableAttributedString
 
 + (TUIAttributedString *)stringWithString:(NSString *)string;
@@ -52,6 +60,8 @@ typedef enum {
 // write-only properties, reading will return nil
 @property (nonatomic, retain) TUIFont *font;
 @property (nonatomic, retain) TUIColor *color;
+@property (nonatomic, retain) TUIColor *backgroundColor;
+@property (nonatomic, assign) TUIBackgroundFillStyle backgroundFillStyle;
 @property (nonatomic, retain) NSShadow *shadow;
 @property (nonatomic, assign) TUITextAlignment alignment; // setting this will set lineBreakMode to word wrap, use setAlignment:lineBreakMode: for more control
 @property (nonatomic, assign) CGFloat kerning;
@@ -62,6 +72,8 @@ typedef enum {
 - (NSRange)_stringRange;
 - (void)setFont:(TUIFont *)font inRange:(NSRange)range;
 - (void)setColor:(TUIColor *)color inRange:(NSRange)range;
+- (void)setBackgroundColor:(TUIColor *)color inRange:(NSRange)range;
+- (void)setBackgroundFillStyle:(TUIBackgroundFillStyle)fillStyle inRange:(NSRange)range;
 - (void)setShadow:(NSShadow *)shadow inRange:(NSRange)range;
 - (void)setKerning:(CGFloat)f inRange:(NSRange)range;
 - (void)setLineHeight:(CGFloat)f inRange:(NSRange)range;

--- a/lib/UIKit/TUIAttributedString.m
+++ b/lib/UIKit/TUIAttributedString.m
@@ -18,6 +18,9 @@
 #import "TUIFont.h"
 #import "TUIColor.h"
 
+NSString * const TUIAttributedStringBackgroundColorAttributeName = @"TUIAttributedStringBackgroundColorAttributeName";
+NSString * const TUIAttributedStringBackgroundFillStyleName = @"TUIAttributedStringBackgroundFillStyleName";
+
 @implementation TUIAttributedString
 
 + (TUIAttributedString *)stringWithString:(NSString *)string
@@ -62,6 +65,26 @@
 - (void)setColor:(TUIColor *)color
 {
 	[self setColor:color inRange:[self _stringRange]];
+}
+
+- (void)setBackgroundColor:(TUIColor *)color
+{
+	[self setBackgroundColor:color inRange:[self _stringRange]];
+}
+
+- (void)setBackgroundColor:(TUIColor *)color inRange:(NSRange)range
+{
+	[self addAttribute:TUIAttributedStringBackgroundColorAttributeName value:(id)[color CGColor] range:range];
+}
+
+- (void)setBackgroundFillStyle:(TUIBackgroundFillStyle)fillStyle
+{
+	[self setBackgroundFillStyle:fillStyle inRange:[self _stringRange]];
+}
+
+- (void)setBackgroundFillStyle:(TUIBackgroundFillStyle)fillStyle inRange:(NSRange)range
+{
+	[self addAttribute:TUIAttributedStringBackgroundFillStyleName value:[NSNumber numberWithInteger:fillStyle] range:range];
 }
 
 - (void)setShadow:(NSShadow *)shadow
@@ -199,6 +222,15 @@ NSParagraphStyle *ABNSParagraphStyleForTextAlignment(TUITextAlignment alignment)
 - (CGFloat)lineHeight
 {
 	return 0.0;
+}
+
+- (TUIColor *)backgroundColor
+{
+	return nil;
+}
+
+- (TUIBackgroundFillStyle)backgroundFillStyle {
+	return TUIBackgroundFillStyleInline;
 }
 
 @end

--- a/lib/UIKit/TUITextRenderer.h
+++ b/lib/UIKit/TUITextRenderer.h
@@ -53,6 +53,7 @@ typedef enum {
 	
 	struct {
 		unsigned int drawMaskDragSelection:1;
+		unsigned int backgroundDrawingEnabled:1;
 	} _flags;
 }
 
@@ -63,6 +64,7 @@ typedef enum {
 @property (nonatomic, assign) CGSize shadowOffset;
 @property (nonatomic, assign) CGFloat shadowBlur;
 @property (nonatomic, retain) TUIColor *shadowColor; // default = nil for no shadow
+@property (nonatomic, assign) BOOL backgroundDrawingEnabled; // default = NO
 
 - (void)draw;
 - (void)drawInContext:(CGContextRef)context;

--- a/lib/UIKit/TUITextRenderer.h
+++ b/lib/UIKit/TUITextRenderer.h
@@ -67,6 +67,7 @@ typedef enum {
 - (void)draw;
 - (void)drawInContext:(CGContextRef)context;
 - (CGSize)size; // calculates vertical size based on frame width
+- (CGSize)sizeConstrainedToWidth:(CGFloat)width;
 - (void)reset;
 
 - (NSRange)selectedRange;

--- a/lib/UIKit/TUITextRenderer.m
+++ b/lib/UIKit/TUITextRenderer.m
@@ -177,28 +177,30 @@
 		
 		CTFrameRef f = [self ctFrame];
 		
-		CGContextSaveGState(context);
-		
-		[self.attributedString enumerateAttribute:TUIAttributedStringBackgroundColorAttributeName inRange:NSMakeRange(0, [self.attributedString length]) options:0 usingBlock:^(id value, NSRange range, BOOL *stop) {
-			if(value == NULL) return;
+		if(self.backgroundDrawingEnabled && !_flags.drawMaskDragSelection) {
+			CGContextSaveGState(context);
 			
-			CGColorRef color = (CGColorRef) value;
-			CGContextSetFillColorWithColor(context, color);
-									
-			CFIndex rectCount = 100;
-			CGRect rects[rectCount];
-			CFRange r = {range.location, range.length};
-			AB_CTFrameGetRectsForRangeWithAggregationType(f, r, (AB_CTLineRectAggregationType)[[self.attributedString attribute:TUIAttributedStringBackgroundFillStyleName atIndex:range.location effectiveRange:NULL] integerValue], rects, &rectCount);
-			for(CFIndex i = 0; i < rectCount; ++i) {
-				CGRect r = rects[i];
-				r = CGRectInset(r, -2, -1);
-				r = CGRectIntegral(r);
-				if(r.size.width > 1)
-					CGContextFillRect(context, r);
-			}
-		}];
-		
-		CGContextRestoreGState(context);
+			[self.attributedString enumerateAttribute:TUIAttributedStringBackgroundColorAttributeName inRange:NSMakeRange(0, [self.attributedString length]) options:0 usingBlock:^(id value, NSRange range, BOOL *stop) {
+				if(value == NULL) return;
+				
+				CGColorRef color = (CGColorRef) value;
+				CGContextSetFillColorWithColor(context, color);
+				
+				CFIndex rectCount = 100;
+				CGRect rects[rectCount];
+				CFRange r = {range.location, range.length};
+				AB_CTFrameGetRectsForRangeWithAggregationType(f, r, (AB_CTLineRectAggregationType)[[self.attributedString attribute:TUIAttributedStringBackgroundFillStyleName atIndex:range.location effectiveRange:NULL] integerValue], rects, &rectCount);
+				for(CFIndex i = 0; i < rectCount; ++i) {
+					CGRect r = rects[i];
+					r = CGRectInset(r, -2, -1);
+					r = CGRectIntegral(r);
+					if(r.size.width > 1)
+						CGContextFillRect(context, r);
+				}
+			}];
+			
+			CGContextRestoreGState(context);
+		}
 		
 		if(hitRange && !_flags.drawMaskDragSelection) {
 			// draw highlight
@@ -300,6 +302,16 @@
 		return rects[0];
 	}
 	return CGRectZero;
+}
+
+- (BOOL)backgroundDrawingEnabled
+{
+	return _flags.backgroundDrawingEnabled;
+}
+
+- (void)setBackgroundDrawingEnabled:(BOOL)enabled
+{
+	_flags.backgroundDrawingEnabled = enabled;
 }
 
 @end


### PR DESCRIPTION
I added the ability to specify a background color for an attributed string rendered by TUITextRenderer. This is implemented in a pretty naive (read: dumb-guy) way, but it works ok. I also added the ability to specify how the background color should fill. Either inline (as it does by default) or block (where it renders across the whole line's length).

I also changed how AB_CTFrameGetSize measures the frame's height. The old way worked fine for short strings but it'd get increasingly off (short) as the string got longer. This new way seems to work for both short and long strings.

(Yeah, re-submitted because I wanted it to be based off my branch instead of master.)
