### PR TITLE
Fast selection

### DIFF
--- a/lib/UIKit/TUITextRenderer+Event.h
+++ b/lib/UIKit/TUITextRenderer+Event.h
@@ -20,6 +20,7 @@
 
 - (CFIndex)stringIndexForPoint:(CGPoint)p;
 - (void)resetSelection;
+- (CGRect)rectForCurrentSelection;
 
 - (void)copy:(id)sender;
 

--- a/lib/UIKit/TUIView.h
+++ b/lib/UIKit/TUIView.h
@@ -93,6 +93,7 @@ extern CGRect(^TUIViewCenteredLayout)(TUIView*);
 		unsigned int pasteboardDraggingEnabled:1;
 		unsigned int pasteboardDraggingIsDragging:1;
 		unsigned int dragDistanceLock:1;
+		unsigned int clearsContextBeforeDrawing:1;
 		
 		unsigned int delegateMouseEntered:1;
 		unsigned int delegateMouseExited:1;
@@ -311,6 +312,11 @@ extern CGRect(^TUIViewCenteredLayout)(TUIView*);
  default is NO. doesn't check superviews
  */
 @property (nonatomic,getter=isHidden) BOOL hidden;
+
+/**
+ default is YES.
+ */
+@property (nonatomic) BOOL clearsContextBeforeDrawing;
 
 @end
 

--- a/lib/UIKit/TUIView.m
+++ b/lib/UIKit/TUIView.m
@@ -259,7 +259,8 @@ else CGContextSetRGBFillColor(context, 1, 0, 0, 0.3); CGContextFillRect(context,
 	CGRect b = self.bounds; \
 	CGContextRef context = [self _CGContext]; \
 	TUIGraphicsPushContext(context); \
-	CGContextClearRect(context, b); \
+	if(self.clearsContextBeforeDrawing) \
+		CGContextClearRect(context, b); \
 	CGContextScaleCTM(context, Screen_Scale, Screen_Scale); \
 	CGContextSetAllowsAntialiasing(context, true); \
 	CGContextSetShouldAntialias(context, true); \
@@ -810,6 +811,14 @@ else CGContextSetRGBFillColor(context, 1, 0, 0, 0.3); CGContextFillRect(context,
 	if(color.alphaComponent < 1.0)
 		self.opaque = NO;
 	[self setNeedsDisplay];
+}
+
+- (BOOL)clearsContextBeforeDrawing {
+	return _viewFlags.clearsContextBeforeDrawing;
+}
+
+- (void)setClearsContextBeforeDrawing:(BOOL)newValue {
+	_viewFlags.clearsContextBeforeDrawing = newValue;
 }
 
 @end


### PR DESCRIPTION
Previously TUITextRenderer would redraw the entire string every time the selection changed. This was pretty painful for performance when the string was really long.

These changes use the dirty rect stuff in #15 to only ask for display in the rect that changed.

(Includes changes from #15 and #14.)
