### PR TITLE
TUITableView delegate: support changes in row selection cause by both mouse and keyboard action

### DIFF
--- a/lib/UIKit/TUITableView.h
+++ b/lib/UIKit/TUITableView.h
@@ -41,8 +41,10 @@ typedef enum {
 @optional
 
 - (void)tableView:(TUITableView *)tableView willDisplayCell:(TUITableViewCell *)cell forRowAtIndexPath:(TUIFastIndexPath *)indexPath; // not implemented yet
-- (void)tableView:(TUITableView *)tableView didSelectRowAtIndexPath:(TUIFastIndexPath *)indexPath; // happens on mouse down
+- (void)tableView:(TUITableView *)tableView didMouseDownAtIndexPath:(TUIFastIndexPath *)indexPath; // happens on mouse down
 - (void)tableView:(TUITableView *)tableView didClickRowAtIndexPath:(TUIFastIndexPath *)indexPath withEvent:(NSEvent *)event; // happens on mouse up (can look at clickCount)
+- (void)tableView:(TUITableView *)tableView didSelectRowAtIndexPath:(TUIFastIndexPath *)indexPath; // Tells the delegate that the specified row is now selected, whether by clicking or key action
+- (void)tableView:(TUITableView *)tableView didDeselectRowAtIndexPath:(TUIFastIndexPath *)indexPath; // Tells the delegate that the specified row is now deselected
 
 @end
 

--- a/lib/UIKit/TUITableView.m
+++ b/lib/UIKit/TUITableView.m
@@ -599,6 +599,8 @@ static NSInteger SortCells(TUITableViewCell *a, TUITableViewCell *b, void *ctx)
 		[cell setSelected:YES animated:animated];
 		[_selectedIndexPath release]; // should already be nil
 		_selectedIndexPath = [indexPath retain];
+		if([self.delegate respondsToSelector:@selector(tableView:didSelectRowAtIndexPath:)])
+			[self.delegate tableView:self didSelectRowAtIndexPath:_selectedIndexPath];
 		[cell setNeedsDisplay];
 	}
 	[self _makeRowAtIndexPathFirstResponder:indexPath];
@@ -612,6 +614,8 @@ static NSInteger SortCells(TUITableViewCell *a, TUITableViewCell *b, void *ctx)
 		[cell setSelected:NO animated:animated];
 		[_selectedIndexPath release];
 		_selectedIndexPath = nil;
+		if([self.delegate respondsToSelector:@selector(tableView:didDeselectRowAtIndexPath:)])
+			[self.delegate tableView:self didDeselectRowAtIndexPath:indexPath];
 		[cell setNeedsDisplay];
 	}
 }

--- a/lib/UIKit/TUITableView.m
+++ b/lib/UIKit/TUITableView.m
@@ -498,17 +498,8 @@ static NSInteger SortCells(TUITableViewCell *a, TUITableViewCell *b, void *ctx)
 }
 
 - (void)reloadData
-{
-	// Store the rects of the current selection to restore its position
-	// after the reload
-	CGRect visibleRect = CGRectZero;
-	CGRect selectedRect = CGRectZero;
-	
-	if (_selectedIndexPath) {
-		visibleRect = [self visibleRect];
-		selectedRect = [self rectForRowAtIndexPath:_selectedIndexPath];
-	}
-	
+{	
+
 	// need to recycle all visible cells, have them be regenerated on layoutSubviews
 	// because the same cells might have different content
 	for(TUIFastIndexPath *i in _visibleItems) {
@@ -536,20 +527,6 @@ static NSInteger SortCells(TUITableViewCell *a, TUITableViewCell *b, void *ctx)
 			[self deselectRowAtIndexPath:_selectedIndexPath animated:NO];
 		}
 		
-		// If the new selection is still valid, try to keep the position of the selected
-		// item in the same position as before the reload take place
-		else {			
-			// Get the rect of the selected row after reload
-			CGRect newVisibleRect = [self rectForRowAtIndexPath:_selectedIndexPath];
-			newVisibleRect.size = self.frame.size;
-			
-			// Adjust the newRect until its relative position to the table view
-			// is similar to where it was before the update
-			newVisibleRect.origin.y -= (selectedRect.origin.y - visibleRect.origin.y);
-			
-			[self scrollRectToVisible:newVisibleRect animated:NO];
-		}
-
 	}
 
 }

--- a/lib/UIKit/TUITableViewCell.m
+++ b/lib/UIKit/TUITableViewCell.m
@@ -76,8 +76,8 @@
 {
 	TUITableView *tableView = self.tableView;
 	[tableView selectRowAtIndexPath:self.indexPath animated:YES scrollPosition:TUITableViewScrollPositionNone];
-	if([tableView.delegate respondsToSelector:@selector(tableView:didSelectRowAtIndexPath:)])
-		[tableView.delegate tableView:tableView didSelectRowAtIndexPath:self.indexPath];
+	if([tableView.delegate respondsToSelector:@selector(tableView:didMouseDownAtIndexPath:)])
+		[tableView.delegate tableView:tableView didMouseDownAtIndexPath:self.indexPath];
 	
 	[super mouseDown:event]; // may make the text renderer first responder, so we want to do the selection before this
 	_tableViewCellFlags.highlighted = 1;


### PR DESCRIPTION
Updated TUITableView delegate methods to support changes in row selection cause by both mouse and keyboard actions
- Renamed delegate method tableView:didSelectRowAtIndexPath: to tableView:didMouseDownAtIndexPath:
- tableView:didSelectRowAtIndexPath: now called by TUITableView whenever a new row is selected (previously called by TUITableViewCell only when mouse down)
- Added tableView:didDeselectRowAtIndexPath: to be called by TUITableView whenever a row is deselected
