### PR TITLE
Quick TUIImageView drawing fix for TUIStretchableImages

### DIFF
--- a/lib/UIKit/TUIImageView.m
+++ b/lib/UIKit/TUIImageView.m
@@ -54,8 +54,8 @@
 	[super drawRect:rect];
 	if (_image == nil)
 		return;
-	CGContextRef ctx = TUIGraphicsGetCurrentContext();
-	CGContextDrawImage(ctx, rect, _image.CGImage);
+    
+    [_image drawInRect:rect];
 }
 
 @end


### PR DESCRIPTION
TUIImageView's drawRect: method should ask the child image to draw, not draw the child images CGImage itself.

This fixes a bug where TUIStretchableImages wouldn't be drawn properly when placed in a TUIImageView.

I've tested this in a small side project and things seem to work fine.
