### PR TITLE
Added pre-draw block support to attributed strings

### DIFF
--- a/lib/UIKit/TUIAttributedString.h
+++ b/lib/UIKit/TUIAttributedString.h
@@ -18,9 +18,12 @@
 
 extern NSString * const TUIAttributedStringBackgroundColorAttributeName;
 extern NSString * const TUIAttributedStringBackgroundFillStyleName;
+extern NSString * const TUIAttributedStringPreDrawBlockName;
 
 @class TUIFont;
 @class TUIColor;
+
+typedef void (^TUIAttributedStringPreDrawBlock)(NSAttributedString *attributedString, NSRange substringRange, CGRect rects[], CFIndex rectCount);
 
 typedef enum {		
 	TUILineBreakModeWordWrap = 0,
@@ -74,6 +77,7 @@ typedef enum {
 - (void)setColor:(TUIColor *)color inRange:(NSRange)range;
 - (void)setBackgroundColor:(TUIColor *)color inRange:(NSRange)range;
 - (void)setBackgroundFillStyle:(TUIBackgroundFillStyle)fillStyle inRange:(NSRange)range;
+- (void)setPreDrawBlock:(TUIAttributedStringPreDrawBlock)block inRange:(NSRange)range; // the pre-draw block is called before the text or text background has been drawn
 - (void)setShadow:(NSShadow *)shadow inRange:(NSRange)range;
 - (void)setKerning:(CGFloat)f inRange:(NSRange)range;
 - (void)setLineHeight:(CGFloat)f inRange:(NSRange)range;

--- a/lib/UIKit/TUIAttributedString.m
+++ b/lib/UIKit/TUIAttributedString.m
@@ -20,6 +20,7 @@
 
 NSString * const TUIAttributedStringBackgroundColorAttributeName = @"TUIAttributedStringBackgroundColorAttributeName";
 NSString * const TUIAttributedStringBackgroundFillStyleName = @"TUIAttributedStringBackgroundFillStyleName";
+NSString * const TUIAttributedStringPreDrawBlockName = @"TUIAttributedStringPreDrawBlockName";
 
 @implementation TUIAttributedString
 
@@ -85,6 +86,11 @@ NSString * const TUIAttributedStringBackgroundFillStyleName = @"TUIAttributedStr
 - (void)setBackgroundFillStyle:(TUIBackgroundFillStyle)fillStyle inRange:(NSRange)range
 {
 	[self addAttribute:TUIAttributedStringBackgroundFillStyleName value:[NSNumber numberWithInteger:fillStyle] range:range];
+}
+
+- (void)setPreDrawBlock:(TUIAttributedStringPreDrawBlock)block inRange:(NSRange)range
+{
+	[self addAttribute:TUIAttributedStringPreDrawBlockName value:[[block copy] autorelease] range:range];
 }
 
 - (void)setShadow:(NSShadow *)shadow

--- a/lib/UIKit/TUITextRenderer+Event.m
+++ b/lib/UIKit/TUITextRenderer+Event.m
@@ -25,6 +25,7 @@
 - (CTFrameRef)ctFrame;
 - (CGPathRef)ctPath;
 - (CFRange)_selectedRange;
+- (CGRect)rectForRange:(CFRange)range;
 @end
 
 @implementation TUITextRenderer (Event)
@@ -225,13 +226,16 @@ normal:
 }
 
 - (CGRect)rectForCurrentSelection {
+	return [self rectForRange:[self _selectedRange]];
+}
+
+- (CGRect)rectForRange:(CFRange)range {
 	CTFrameRef textFrame = [self ctFrame];
 	CGRect totalRect = CGRectNull;
-	CFRange selectedRange = [self _selectedRange];
-	if(selectedRange.length > 0) {
+	if(range.length > 0) {
 		CFIndex rectCount = 100;
 		CGRect rects[rectCount];
-		AB_CTFrameGetRectsForRange(textFrame, selectedRange, rects, &rectCount);
+		AB_CTFrameGetRectsForRangeWithAggregationType(textFrame, range, AB_CTLineRectAggregationTypeBlock, rects, &rectCount);
 		
 		for(CFIndex i = 0; i < rectCount; ++i) {
 			CGRect rect = rects[i];

--- a/lib/UIKit/TUITextRenderer.h
+++ b/lib/UIKit/TUITextRenderer.h
@@ -54,6 +54,7 @@ typedef enum {
 	struct {
 		unsigned int drawMaskDragSelection:1;
 		unsigned int backgroundDrawingEnabled:1;
+		unsigned int preDrawBlocksEnabled:1;
 	} _flags;
 }
 
@@ -64,7 +65,10 @@ typedef enum {
 @property (nonatomic, assign) CGSize shadowOffset;
 @property (nonatomic, assign) CGFloat shadowBlur;
 @property (nonatomic, retain) TUIColor *shadowColor; // default = nil for no shadow
+
+// These are both advanced features that carry with them a potential performance hit.
 @property (nonatomic, assign) BOOL backgroundDrawingEnabled; // default = NO
+@property (nonatomic, assign) BOOL preDrawBlocksEnabled; // default = NO
 
 - (void)draw;
 - (void)drawInContext:(CGContextRef)context;
@@ -77,6 +81,7 @@ typedef enum {
 - (NSString *)selectedString;
 
 - (CGRect)firstRectForCharacterRange:(CFRange)range;
+- (NSArray *)rectsForCharacterRange:(CFRange)range;
 
 @property (nonatomic, retain) id<ABActiveTextRange> hitRange;
 

--- a/lib/UIKit/TUITextRenderer.m
+++ b/lib/UIKit/TUITextRenderer.m
@@ -177,7 +177,24 @@
 		
 		CTFrameRef f = [self ctFrame];
 		
-		if(self.backgroundDrawingEnabled && !_flags.drawMaskDragSelection) {
+		if(_flags.preDrawBlocksEnabled && !_flags.drawMaskDragSelection) {
+			[self.attributedString enumerateAttribute:TUIAttributedStringPreDrawBlockName inRange:NSMakeRange(0, [self.attributedString length]) options:0 usingBlock:^(id value, NSRange range, BOOL *stop) {
+				if(value == NULL) return;
+				
+				CGContextSaveGState(context);
+				
+				CFIndex rectCount = 100;
+				CGRect rects[rectCount];
+				CFRange r = {range.location, range.length};
+				AB_CTFrameGetRectsForRangeWithAggregationType(f, r, (AB_CTLineRectAggregationType)[[self.attributedString attribute:TUIAttributedStringBackgroundFillStyleName atIndex:range.location effectiveRange:NULL] integerValue], rects, &rectCount);
+				TUIAttributedStringPreDrawBlock block = value;
+				block(self.attributedString, range, rects, rectCount);
+				
+				CGContextRestoreGState(context);
+			}];
+		}
+		
+		if(_flags.backgroundDrawingEnabled && !_flags.drawMaskDragSelection) {
 			CGContextSaveGState(context);
 			
 			[self.attributedString enumerateAttribute:TUIAttributedStringBackgroundColorAttributeName inRange:NSMakeRange(0, [self.attributedString length]) options:0 usingBlock:^(id value, NSRange range, BOOL *stop) {
@@ -304,6 +321,20 @@
 	return CGRectZero;
 }
 
+- (NSArray *)rectsForCharacterRange:(CFRange)range
+{
+	CFIndex rectCount = 100;
+	CGRect rects[rectCount];
+	AB_CTFrameGetRectsForRange([self ctFrame], range, rects, &rectCount);
+	
+	NSMutableArray *wrappedRects = [NSMutableArray arrayWithCapacity:rectCount];
+	for(CFIndex i = 0; i < rectCount; i++) {
+		[wrappedRects addObject:[NSValue valueWithRect:rects[i]]];
+	}
+	
+	return [[wrappedRects copy] autorelease];
+}
+
 - (BOOL)backgroundDrawingEnabled
 {
 	return _flags.backgroundDrawingEnabled;
@@ -312,6 +343,16 @@
 - (void)setBackgroundDrawingEnabled:(BOOL)enabled
 {
 	_flags.backgroundDrawingEnabled = enabled;
+}
+
+- (BOOL)preDrawBlocksEnabled
+{
+	return _flags.preDrawBlocksEnabled;
+}
+
+- (void)setPreDrawBlocksEnabled:(BOOL)enabled
+{
+	_flags.preDrawBlocksEnabled = enabled;
 }
 
 @end


### PR DESCRIPTION
You can set a block to be called with the given substring range before that text is actually drawn. Allows for more customization of background drawing.
