### PR TITLE
Keep the scroll position after -reloadData by maintaining and restoring the contentOffset

### DIFF
--- a/lib/UIKit/TUITableView.h
+++ b/lib/UIKit/TUITableView.h
@@ -77,6 +77,7 @@ typedef enum {
 		unsigned int didFirstLayout:1;
 		unsigned int dataSourceNumberOfSectionsInTableView:1;
 		unsigned int delegateTableViewWillDisplayCellForRowAtIndexPath:1;
+		unsigned int maintainContentOffsetAfterReload:1;
 	} _tableFlags;
 }
 
@@ -86,6 +87,7 @@ typedef enum {
 @property (nonatomic,assign) id <TUITableViewDelegate>    delegate;
 
 @property (readwrite, assign) BOOL                        animateSelectionChanges;
+@property (nonatomic, assign) BOOL maintainContentOffsetAfterReload;
 
 - (void)reloadData;
 


### PR DESCRIPTION
To me, this kinda seems like it should be the default behavior but I'll freely admit I might be missing something :)

This tries to ensure that the scroll position doesn't change after calling `-reloadData`. If, for instance, the table view grows, this makes it behave like you'd probably expect it to (you won't be suddenly scrolled to the bottom).
