### PR TITLE
Adding drag-to-reorder rows support to TUITableView, fixes to section header support

### DIFF
--- a/ExampleProject/ConcordeExample/ExampleSectionHeaderView.m
+++ b/ExampleProject/ConcordeExample/ExampleSectionHeaderView.m
@@ -30,9 +30,18 @@
   
   CGContextRef g;
   if((g = TUIGraphicsGetCurrentContext()) != nil){
+    [NSGraphicsContext setCurrentContext:[NSGraphicsContext graphicsContextWithGraphicsPort:g flipped:FALSE]];
     
-    CGContextSetRGBFillColor(g, 0.8, 0.8, 0.8, 1);
-    CGContextFillRect(g, self.bounds);
+    NSColor *start = [NSColor colorWithCalibratedRed:0.8 green:0.8 blue:0.8 alpha:1];
+    NSColor *end = [NSColor colorWithCalibratedRed:0.9 green:0.9 blue:0.9 alpha:1];
+    NSGradient *gradient = nil;
+    
+    gradient = [[NSGradient alloc] initWithStartingColor:start endingColor:end];
+    [gradient drawInRect:self.bounds angle:90];
+    [gradient release];
+    
+    [[start shadowWithLevel:0.1] set];
+    NSRectFill(NSMakeRect(0, 0, self.bounds.size.width, 1));
     
     CGFloat labelHeight = 18;
     self.labelRenderer.frame = CGRectMake(15, roundf((self.bounds.size.height - labelHeight) / 2.0), self.bounds.size.width - 30, labelHeight);

--- a/ExampleProject/ConcordeExample/ExampleView.m
+++ b/ExampleProject/ConcordeExample/ExampleView.m
@@ -115,6 +115,10 @@
 - (void)tabBar:(ExampleTabBar *)tabBar didSelectTab:(NSInteger)index
 {
 	NSLog(@"selected tab %ld", index);
+	if(index == [[tabBar tabViews] count] - 1){
+	  NSLog(@"Reload table data...");
+	  [_tableView reloadData];
+	}
 }
 
 - (NSInteger)numberOfSectionsInTableView:(TUITableView *)tableView
@@ -160,6 +164,25 @@
 	if([event clickCount] == 1) {
 		// do something cool
 	}
+}
+
+-(BOOL)tableView:(TUITableView *)tableView canMoveRowAtIndexPath:(TUIFastIndexPath *)indexPath {
+  // return TRUE to enable row reordering by dragging; don't implement this method or return
+  // FALSE to disable
+  return TRUE;
+}
+
+-(void)tableView:(TUITableView *)tableView moveRowAtIndexPath:(TUIFastIndexPath *)fromIndexPath toIndexPath:(TUIFastIndexPath *)toIndexPath {
+  // update the model to reflect the changed index paths; since this example isn't backed by
+  // a "real" model, after dropping a cell the table will revert to it's previous state
+  NSLog(@"Move dragged row: %@ => %@", fromIndexPath, toIndexPath);
+}
+
+-(TUIFastIndexPath *)tableView:(TUITableView *)tableView targetIndexPathForMoveFromRowAtIndexPath:(TUIFastIndexPath *)fromPath toProposedIndexPath:(TUIFastIndexPath *)proposedPath {
+  // optionally revise the drag-to-reorder drop target index path by returning a different index path
+  // than proposedPath.  if proposedPath is suitable, return that.  if this method is not implemented,
+  // proposedPath is used by default.
+  return proposedPath;
 }
 
 @end

--- a/ExampleProject/ConcordeExample/ExampleView.m
+++ b/ExampleProject/ConcordeExample/ExampleView.m
@@ -44,6 +44,7 @@
 		_tableView.autoresizingMask = TUIViewAutoresizingFlexibleSize;
 		_tableView.dataSource = self;
 		_tableView.delegate = self;
+		_tableView.maintainContentOffsetAfterReload = TRUE;
 		[self addSubview:_tableView];
 		
 		_tabBar = [[ExampleTabBar alloc] initWithNumberOfTabs:5];

--- a/ExampleProject/Example.xcodeproj/project.pbxproj
+++ b/ExampleProject/Example.xcodeproj/project.pbxproj
@@ -65,6 +65,7 @@
 		5ED56727139DC35100031CDF /* TUIView.m in Sources */ = {isa = PBXBuildFile; fileRef = 5ED566F2139DC35100031CDF /* TUIView.m */; };
 		5ED56728139DC35100031CDF /* TUIViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 5ED566F4139DC35100031CDF /* TUIViewController.m */; };
 		5ED56736139DC35800031CDF /* CoreText+Additions.m in Sources */ = {isa = PBXBuildFile; fileRef = 5ED56732139DC35800031CDF /* CoreText+Additions.m */; };
+		D3502AAE13EA0FE4007C5CA7 /* TUITableView+Cell.m in Sources */ = {isa = PBXBuildFile; fileRef = D3502AAD13EA0FE4007C5CA7 /* TUITableView+Cell.m */; };
 		D3CE671313C6646B00D47B2D /* ExampleSectionHeaderView.m in Sources */ = {isa = PBXBuildFile; fileRef = D3CE671213C6646B00D47B2D /* ExampleSectionHeaderView.m */; };
 /* End PBXBuildFile section */
 
@@ -178,6 +179,8 @@
 		5ED566F5139DC35100031CDF /* TUIViewNSViewContainer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TUIViewNSViewContainer.h; sourceTree = "<group>"; };
 		5ED56731139DC35800031CDF /* CoreText+Additions.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = "CoreText+Additions.h"; path = "../Support/CoreText+Additions.h"; sourceTree = "<group>"; };
 		5ED56732139DC35800031CDF /* CoreText+Additions.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = "CoreText+Additions.m"; path = "../Support/CoreText+Additions.m"; sourceTree = "<group>"; };
+		D3502AAC13EA0FE4007C5CA7 /* TUITableView+Cell.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "TUITableView+Cell.h"; sourceTree = "<group>"; };
+		D3502AAD13EA0FE4007C5CA7 /* TUITableView+Cell.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "TUITableView+Cell.m"; sourceTree = "<group>"; };
 		D3CE671113C6646B00D47B2D /* ExampleSectionHeaderView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ExampleSectionHeaderView.h; sourceTree = "<group>"; };
 		D3CE671213C6646B00D47B2D /* ExampleSectionHeaderView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ExampleSectionHeaderView.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -333,6 +336,8 @@
 				5ED566D0139DC35100031CDF /* TUITableView+Additions.m */,
 				5ED566D1139DC35100031CDF /* TUITableView+Derepeater.h */,
 				5ED566D2139DC35100031CDF /* TUITableView+Derepeater.m */,
+				D3502AAC13EA0FE4007C5CA7 /* TUITableView+Cell.h */,
+				D3502AAD13EA0FE4007C5CA7 /* TUITableView+Cell.m */,
 				5ED566D5139DC35100031CDF /* TUITableViewCell.h */,
 				5ED566D6139DC35100031CDF /* TUITableViewCell.m */,
 				5ED56698139DC35100031CDF /* TUIActivityIndicatorView.h */,
@@ -483,6 +488,7 @@
 				5C55D83713A66BD5000ED768 /* ExampleTableViewCell.m in Sources */,
 				5C90DB9D13A7C08E00ECDD14 /* ExampleTabBar.m in Sources */,
 				D3CE671313C6646B00D47B2D /* ExampleSectionHeaderView.m in Sources */,
+				D3502AAE13EA0FE4007C5CA7 /* TUITableView+Cell.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/lib/UIKit/TUIControl.h
+++ b/lib/UIKit/TUIControl.h
@@ -17,36 +17,37 @@
 #import "TUIView.h"
 
 enum {
-    TUIControlEventTouchDown           = 1 <<  0,
-    TUIControlEventTouchDownRepeat     = 1 <<  1,
-	TUIControlEventTouchUpInside       = 1 <<  6,
-	TUIControlEventTouchUpOutside      = 1 <<  7,
-    TUIControlEventValueChanged        = 1 << 12,
-    TUIControlEventEditingDidEndOnExit = 1 << 19,
-    TUIControlEventAllTouchEvents      = 0x00000FFF,
-    TUIControlEventAllEditingEvents    = 0x000F0000,
-    TUIControlEventApplicationReserved = 0x0F000000,
-    TUIControlEventSystemReserved      = 0xF0000000,
-    TUIControlEventAllEvents           = 0xFFFFFFFF
+  TUIControlEventTouchDown           = 1 <<  0,
+  TUIControlEventTouchDownRepeat     = 1 <<  1,
+  TUIControlEventTouchUpInside       = 1 <<  6,
+  TUIControlEventTouchUpOutside      = 1 <<  7,
+  TUIControlEventValueChanged        = 1 << 12,
+  TUIControlEventEditingDidEndOnExit = 1 << 19,
+  TUIControlEventAllTouchEvents      = 0x00000FFF,
+  TUIControlEventAllEditingEvents    = 0x000F0000,
+  TUIControlEventApplicationReserved = 0x0F000000,
+  TUIControlEventSystemReserved      = 0xF0000000,
+  TUIControlEventAllEvents           = 0xFFFFFFFF
 };
 typedef NSUInteger TUIControlEvents;
 
 enum {
-	TUIControlStateNormal       = 0,                       
-	TUIControlStateHighlighted  = 1 << 0,
-	TUIControlStateDisabled     = 1 << 1,
-	TUIControlStateSelected     = 1 << 2,
-	TUIControlStateNotKey		 = 1 << 11,
-	TUIControlStateApplication  = 0x00FF0000,
-	TUIControlStateReserved     = 0xFF000000
+  TUIControlStateNormal       = 0,                       
+  TUIControlStateHighlighted  = 1 << 0,
+  TUIControlStateDisabled     = 1 << 1,
+  TUIControlStateSelected     = 1 << 2,
+  TUIControlStateNotKey       = 1 << 11,
+  TUIControlStateApplication  = 0x00FF0000,
+  TUIControlStateReserved     = 0xFF000000
 };
 typedef NSUInteger TUIControlState;
 
 @interface TUIControl : TUIView
 {
-	NSMutableArray* _targetActions;
+  NSMutableArray*   _targetActions;
 	struct {
 		unsigned int disabled:1;
+		unsigned int selected:1;
 		unsigned int acceptsFirstMouse:1;
 		unsigned int tracking:1;
 	} _controlFlags;
@@ -56,6 +57,7 @@ typedef NSUInteger TUIControlState;
 
 @property(nonatomic,readonly) TUIControlState state;
 @property(nonatomic,readonly,getter=isTracking) BOOL tracking;
+@property(nonatomic,assign) BOOL selected;
 
 @property (nonatomic, assign) BOOL acceptsFirstMouse;
 

--- a/lib/UIKit/TUIControl.m
+++ b/lib/UIKit/TUIControl.m
@@ -57,9 +57,45 @@
 
 - (TUIControlState)state
 {
-	if(_controlFlags.tracking)
-		return TUIControlStateHighlighted;
-	return [self.nsWindow isKeyWindow]?TUIControlStateNormal:TUIControlStateNotKey;
+  // start with the normal state, then OR in implicit state that is based on other properties
+  TUIControlState actual = TUIControlStateNormal
+  
+  if(_controlFlags.disabled)        actual |= TUIControlStateDisabled;
+  if(_controlFlags.selected)        actual |= TUIControlStateSelected;
+	if(_controlFlags.tracking)        actual |= TUIControlStateHighlighted;
+	if(![self.nsWindow isKeyWindow])  actual |= TUIControlStateNotKey;
+	
+	return actual;
+}
+
+/**
+ * @brief Determine if this control is in a selected state
+ * 
+ * Not all controls have a selected state and the meaning of "selected" is left
+ * to individual control implementations to define.
+ * 
+ * @return selected or not
+ * 
+ * @note This is a convenience interface to the #state property.
+ * @see #state
+ */
+-(BOOL)selected {
+  return _controlFlags.selected;
+}
+
+/**
+ * @brief Specify whether this control is in a selected state
+ * 
+ * Not all controls have a selected state and the meaning of "selected" is left
+ * to individual control implementations to define.
+ * 
+ * @param selected selected or not
+ * 
+ * @see #state
+ */
+-(void)setSelected:(BOOL)selected {
+  _controlFlags.selected = selected;
+  [self setNeedsDisplay]; // better safe than sorry...
 }
 
 - (BOOL)acceptsFirstMouse

--- a/lib/UIKit/TUIControl.m
+++ b/lib/UIKit/TUIControl.m
@@ -58,7 +58,7 @@
 - (TUIControlState)state
 {
   // start with the normal state, then OR in implicit state that is based on other properties
-  TUIControlState actual = TUIControlStateNormal
+  TUIControlState actual = TUIControlStateNormal;
   
   if(_controlFlags.disabled)        actual |= TUIControlStateDisabled;
   if(_controlFlags.selected)        actual |= TUIControlStateSelected;
@@ -94,8 +94,10 @@
  * @see #state
  */
 -(void)setSelected:(BOOL)selected {
+	[self _stateWillChange];
   _controlFlags.selected = selected;
-  [self setNeedsDisplay]; // better safe than sorry...
+	[self _stateDidChange];
+  [self setNeedsDisplay];
 }
 
 - (BOOL)acceptsFirstMouse
@@ -116,19 +118,39 @@
 - (void)mouseDown:(NSEvent *)event
 {
 	[super mouseDown:event];
+	
+	// handle state change
 	[self _stateWillChange];
 	_controlFlags.tracking = 1;
 	[self _stateDidChange];
+	
+  // handle touch down
+  [self sendActionsForControlEvents:TUIControlEventTouchDown];
+  
+	// needs display
 	[self setNeedsDisplay];
+	
 }
 
 - (void)mouseUp:(NSEvent *)event
 {
 	[super mouseUp:event];
+	
+	// handle state change
 	[self _stateWillChange];
 	_controlFlags.tracking = 0;
 	[self _stateDidChange];
+	
+  // handle touch up
+  if([self pointInside:[self localPointForEvent:event] withEvent:event]){
+    [self sendActionsForControlEvents:TUIControlEventTouchUpInside];
+  }else{
+    [self sendActionsForControlEvents:TUIControlEventTouchUpOutside];
+  }
+	
+  // needs display
 	[self setNeedsDisplay];
+	
 }
 
 @end

--- a/lib/UIKit/TUIGeometry.h
+++ b/lib/UIKit/TUIGeometry.h
@@ -38,3 +38,18 @@ static inline BOOL TUIEdgeInsetsEqualToEdgeInsets(TUIEdgeInsets insets1, TUIEdge
 }
 
 extern const TUIEdgeInsets TUIEdgeInsetsZero;
+
+/**
+ * @brief Constrain a point to a rectangular region
+ * 
+ * If the provided @p point lies outside the @p rect, it is adjusted to the
+ * nearest point that lies inside the @p rect.
+ * 
+ * @param point a point
+ * @param rect the constraining rect
+ * @return constrained point
+ */
+static inline CGPoint CGPointConstrainToRect(CGPoint point, CGRect rect) {
+  return CGPointMake(MAX(rect.origin.x, MIN((rect.origin.x + rect.size.width), point.x)), MAX(rect.origin.y, MIN((rect.origin.y + rect.size.height), point.y)));
+}
+

--- a/lib/UIKit/TUINSView.m
+++ b/lib/UIKit/TUINSView.m
@@ -131,6 +131,12 @@
 	}
 }
 
+- (void)viewDidMoveToWindow {
+	if(self.window != nil && rootView.layer.superlayer != [self layer]) {
+		[[self layer] addSublayer:rootView.layer];
+	}
+}
+
 - (TUIView *)viewForLocalPoint:(NSPoint)p
 {
 	return [rootView hitTest:p withEvent:nil];

--- a/lib/UIKit/TUIScrollView.h
+++ b/lib/UIKit/TUIScrollView.h
@@ -92,6 +92,8 @@ typedef enum {
 		BOOL pulling; // horizontal pulling not done yet, this flag should be split
 	} _pull;
 	
+	CGPoint _dragScrollLocation;
+	
 	BOOL x;
 	
 	struct {
@@ -103,7 +105,7 @@ typedef enum {
 		unsigned int scrollDisabled:1;
 		unsigned int indicatorStyle:2;
 		unsigned int showsHorizontalScrollIndicator:1;
-        unsigned int showsVerticalScrollIndicator:1;
+		unsigned int showsVerticalScrollIndicator:1;
 		unsigned int delegateScrollViewDidScroll:1;
 		unsigned int delegateScrollViewWillBeginDragging:1;
 		unsigned int delegateScrollViewDidEndDragging:1;
@@ -125,6 +127,9 @@ typedef enum {
 - (void)scrollRectToVisible:(CGRect)rect animated:(BOOL)animated;
 - (void)scrollToTopAnimated:(BOOL)animated;
 - (void)scrollToBottomAnimated:(BOOL)animated;
+
+- (void)beginContinuousScrollForDragAtPoint:(CGPoint)dragLocation animated:(BOOL)animated;
+- (void)endContinuousScrollAnimated:(BOOL)animated;
 
 @property (nonatomic, readonly) CGRect visibleRect;
 

--- a/lib/UIKit/TUITableView+Cell.h
+++ b/lib/UIKit/TUITableView+Cell.h
@@ -1,0 +1,29 @@
+/*
+ Copyright 2011 Twitter, Inc.
+ 
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this work except in compliance with the License.
+ You may obtain a copy of the License in the LICENSE file, or at:
+ 
+ http://www.apache.org/licenses/LICENSE-2.0
+ 
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import "TUITableView.h"
+
+/**
+ * @brief Exposes internal table view methods to cells.
+ */
+@interface TUITableView (Cell)
+
+-(void)__mouseDownInCell:(TUITableViewCell *)cell offset:(CGPoint)offset event:(NSEvent *)event;
+-(void)__mouseUpInCell:(TUITableViewCell *)cell offset:(CGPoint)offset event:(NSEvent *)event;
+-(void)__mouseDraggedCell:(TUITableViewCell *)cell offset:(CGPoint)offset event:(NSEvent *)event;
+
+@end
+

--- a/lib/UIKit/TUITableView+Cell.h
+++ b/lib/UIKit/TUITableView+Cell.h
@@ -25,5 +25,10 @@
 -(void)__mouseUpInCell:(TUITableViewCell *)cell offset:(CGPoint)offset event:(NSEvent *)event;
 -(void)__mouseDraggedCell:(TUITableViewCell *)cell offset:(CGPoint)offset event:(NSEvent *)event;
 
+-(BOOL)__isDraggingCell;
+-(void)__beginDraggingCell:(TUITableViewCell *)cell offset:(CGPoint)offset location:(CGPoint)location;
+-(void)__updateDraggingCell:(TUITableViewCell *)cell offset:(CGPoint)offset location:(CGPoint)location;
+-(void)__endDraggingCell:(TUITableViewCell *)cell offset:(CGPoint)offset location:(CGPoint)location;
+
 @end
 

--- a/lib/UIKit/TUITableView+Cell.h
+++ b/lib/UIKit/TUITableView+Cell.h
@@ -17,7 +17,7 @@
 #import "TUITableView.h"
 
 /**
- * @brief Exposes internal table view methods to cells.
+ * @brief Exposes some internal table view methods to cells (primarily for drag-to-reorder support)
  */
 @interface TUITableView (Cell)
 

--- a/lib/UIKit/TUITableView+Cell.m
+++ b/lib/UIKit/TUITableView+Cell.m
@@ -328,16 +328,8 @@
       [TUIView animateWithDuration:0.2
         animations:^ { cell.frame = frame; }
         completion:^(BOOL finished) {
-          
-          if(finished){
-            // i think the following should be suitable to ensure the state is consistent after
-            // reordering, but i'm not completely sure about that...
-            [self _preLayoutCells];
-            [super layoutSubviews];
-            [self _layoutSectionHeaders:TRUE];
-            [self _layoutCells:TRUE];
-          }
-          
+          // reload the table when we're done
+          if(finished) [self reloadData];
           // restore user interactivity
           [self setUserInteractionEnabled:TRUE];
         }

--- a/lib/UIKit/TUITableView+Cell.m
+++ b/lib/UIKit/TUITableView+Cell.m
@@ -144,7 +144,19 @@
   
   // allow the delegate to revise the proposed index path if it wants to
   if(self.delegate != nil && [self.delegate respondsToSelector:@selector(tableView:targetIndexPathForMoveFromRowAtIndexPath:toProposedIndexPath:)]){
+    TUIFastIndexPath *proposedPath = currentPath;
     currentPath = [self.delegate tableView:self targetIndexPathForMoveFromRowAtIndexPath:cell.indexPath toProposedIndexPath:currentPath];
+    // revised index paths always use the "at" insertion method
+    switch([currentPath compare:proposedPath]){
+      case NSOrderedAscending:
+      case NSOrderedDescending:
+        insertMethod = TUITableViewInsertionMethodAtIndex;
+        break;
+      case NSOrderedSame:
+      default:
+        // do nothing
+        break;
+    }
   }
   
   // note the previous path
@@ -184,6 +196,7 @@
       [TUIView beginAnimations:NSStringFromSelector(_cmd) context:NULL];
     }
     
+    // update section headers
     for(NSInteger i = fromIndexPath.section; i <= toIndexPath.section; i++){
       TUIView *headerView;
       if(currentPath.section < i && i <= cell.indexPath.section){
@@ -208,9 +221,10 @@
       }
     }
     
+    // update rows
     [self enumerateIndexPathsFromIndexPath:fromIndexPath toIndexPath:toIndexPath withOptions:0 usingBlock:^(TUIFastIndexPath *indexPath, BOOL *stop) {
       TUITableViewCell *displacedCell;
-      if((displacedCell = [self cellForRowAtIndexPath:indexPath]) != nil){
+      if((displacedCell = [self cellForRowAtIndexPath:indexPath]) != nil && ![displacedCell isEqual:cell]){
         CGRect frame = [self rectForRowAtIndexPath:indexPath];
         CGRect target;
         

--- a/lib/UIKit/TUITableView+Cell.m
+++ b/lib/UIKit/TUITableView+Cell.m
@@ -104,9 +104,15 @@
     // if we're on a section header (but not the first one, which can't move) we insert after the last index in the
     // preceding section
     if((sectionIndex = [self indexOfSectionWithHeaderAtPoint:CGPointMake(location.x, location.y + visible.origin.y)]) > 0){
-      NSInteger previousSectionIndex = sectionIndex - 1;
-      currentPath = [TUIFastIndexPath indexPathForRow:[self numberOfRowsInSection:previousSectionIndex] - 1 inSection:previousSectionIndex];
-      insertMethod = TUITableViewInsertionMethodAfterIndex;
+      if(sectionIndex <= cell.indexPath.section){
+        NSInteger targetSectionIndex = sectionIndex - 1;
+        currentPath = [TUIFastIndexPath indexPathForRow:[self numberOfRowsInSection:targetSectionIndex] - 1 inSection:targetSectionIndex];
+        insertMethod = TUITableViewInsertionMethodAfterIndex;
+      }else{
+        NSInteger targetSectionIndex = sectionIndex;
+        currentPath = [TUIFastIndexPath indexPathForRow:0 inSection:targetSectionIndex];
+        insertMethod = TUITableViewInsertionMethodBeforeIndex;
+      }
     }
   }
   
@@ -189,6 +195,10 @@
         
         if([indexPath isEqual:currentPath] && insertMethod == TUITableViewInsertionMethodAfterIndex){
           // the visited index path is the current index path and the insertion method is "after";
+          // leave the cell where it is, the section header should shift out of the way instead
+          target = frame;
+        }else if([indexPath isEqual:currentPath] && insertMethod == TUITableViewInsertionMethodBeforeIndex){
+          // the visited index path is the current index path and the insertion method is "before";
           // leave the cell where it is, the section header should shift out of the way instead
           target = frame;
         }else if([indexPath compare:currentPath] != NSOrderedAscending && [indexPath compare:cell.indexPath] == NSOrderedAscending){

--- a/lib/UIKit/TUITableView+Cell.m
+++ b/lib/UIKit/TUITableView+Cell.m
@@ -111,8 +111,23 @@
         irow = currentPath.row;
       }
       
-      // update rows
       for(int i = currentPath.section; i < [self numberOfSections]; i++){
+        
+        // update headers, if present
+        if(i > currentPath.section){
+          TUIView *headerView;
+          if((headerView = [self headerViewForSection:i]) != nil){
+            [self addSubview:headerView];
+            CGRect frame = [self rectForHeaderOfSection:i];
+            if(relativeDirection == NSOrderedDescending || relativeDirection == NSOrderedSame){
+              headerView.frame = frame;
+            }else if(relativeDirection == NSOrderedAscending){
+              headerView.frame = CGRectMake(frame.origin.x, frame.origin.y - cell.frame.size.height, frame.size.width, frame.size.height);
+            }
+          }
+        }
+        
+        // update rows
         for(int j = irow; j < [self numberOfRowsInSection:i]; j++){
           TUIFastIndexPath *path = [TUIFastIndexPath indexPathForRow:j inSection:i];
           TUITableViewCell *displacedCell;

--- a/lib/UIKit/TUITableView+Cell.m
+++ b/lib/UIKit/TUITableView+Cell.m
@@ -1,0 +1,142 @@
+/*
+ Copyright 2011 Twitter, Inc.
+ 
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this work except in compliance with the License.
+ You may obtain a copy of the License in the LICENSE file, or at:
+ 
+ http://www.apache.org/licenses/LICENSE-2.0
+ 
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */
+
+#import "TUITableView+Cell.h"
+
+@implementation TUITableView (Cell)
+
+/**
+ * @brief Mouse down in a cell
+ */
+-(void)__mouseDownInCell:(TUITableViewCell *)cell offset:(CGPoint)offset event:(NSEvent *)event {
+  [_referenceDragToReorderIndexPath release];
+  _referenceDragToReorderIndexPath = [cell.indexPath retain];
+  [_currentDragToReorderIndexPath release];
+  _currentDragToReorderIndexPath = [cell.indexPath retain];
+  [_previousDragToReorderIndexPath release];
+  _previousDragToReorderIndexPath = [cell.indexPath retain];
+}
+
+/**
+ * @brief Mouse up in a cell
+ */
+-(void)__mouseUpInCell:(TUITableViewCell *)cell offset:(CGPoint)offset event:(NSEvent *)event {
+  [_referenceDragToReorderIndexPath release];
+  _referenceDragToReorderIndexPath = nil;
+  [_currentDragToReorderIndexPath release];
+  _currentDragToReorderIndexPath = nil;
+  [_previousDragToReorderIndexPath release];
+  _previousDragToReorderIndexPath = nil;
+}
+
+/**
+ * @brief A cell was dragged
+ * 
+ * If reordering is permitted by the table, this will begin a move operation.
+ */
+-(void)__mouseDraggedCell:(TUITableViewCell *)cell offset:(CGPoint)offset event:(NSEvent *)event {
+  
+  // determine if reordering this cell is permitted or not via our delegate
+  if(self.delegate == nil || ![self.delegate respondsToSelector:@selector(tableView:allowsReorderingOfRowAtIndexPath:)] || ![self.delegate tableView:self allowsReorderingOfRowAtIndexPath:cell.indexPath]){
+    return; // reordering cells is not permitted
+  }
+  
+  CGPoint location = [[cell superview] localPointForEvent:event];
+  CGRect visible = [self visibleRect];
+  
+  // dragged cell destination frame
+  CGRect dest = CGRectMake(0, roundf(MAX(0, MIN(visible.origin.y + visible.size.height - cell.frame.size.height, location.y + visible.origin.y - offset.y))), self.bounds.size.width, cell.frame.size.height);
+  
+  // determine the current index path the cell is occupying
+  TUIFastIndexPath *currentPath;
+  if((currentPath = [self indexPathForRowAtPoint:CGPointMake(location.x, location.y + visible.origin.y)]) != nil){
+    // allow the delegate to revise the proposed index path if it wants to
+    if(self.delegate != nil && [self.delegate respondsToSelector:@selector(tableView:targetIndexPathForMoveFromRowAtIndexPath:toProposedIndexPath:)]){
+      currentPath = [self.delegate tableView:self targetIndexPathForMoveFromRowAtIndexPath:cell.indexPath toProposedIndexPath:currentPath];
+    }
+  }
+  
+  // note the previous path
+  [_previousDragToReorderIndexPath release];
+  _previousDragToReorderIndexPath = [_currentDragToReorderIndexPath retain];
+  
+  // determine the current drag direction
+  NSComparisonResult currentDragDirection = (_previousDragToReorderIndexPath != nil) ? [currentPath compare:_previousDragToReorderIndexPath] : NSOrderedSame;
+  
+  // we now have the final destination index path.  if it's not nil, update surrounding
+  // cells to make room for the dragged cell
+  if(currentPath != nil && (_currentDragToReorderIndexPath == nil || ![currentPath isEqual:_currentDragToReorderIndexPath])){
+    TUIFastIndexPath *previousPath = (_currentDragToReorderIndexPath == nil) ? cell.indexPath : _currentDragToReorderIndexPath;
+    
+    // determine whether we're above or below the original index path and handle the
+    // reordering accodringly
+    if(currentDragDirection == NSOrderedAscending){
+      NSLog(@"Above: %@", currentPath);
+      CGFloat adjust = ([currentPath compare:cell.indexPath] == NSOrderedDescending) ? 1 : 0;
+      
+      int irow = currentPath.row;
+      for(int i = currentPath.section; i < [self numberOfSections]; i++){
+        for(int j = irow; j < [self numberOfRowsInSection:i]; j++){
+          TUIFastIndexPath *path = [TUIFastIndexPath indexPathForRow:j inSection:i];
+          TUITableViewCell *displacedCell;
+          if([path isEqual:_previousDragToReorderIndexPath]){
+            goto done; // stop when we hit the original row
+          }else if((displacedCell = [self cellForRowAtIndexPath:path]) != nil){
+            CGRect frame = [self rectForRowAtIndexPath:path];
+            displacedCell.frame = CGRectMake(frame.origin.x, frame.origin.y - cell.frame.size.height, frame.size.width, frame.size.height);
+          }
+        }
+        irow = 0;
+      }
+      
+    }else if(currentDragDirection == NSOrderedDescending){
+      NSLog(@"Below: %@ (%@)", currentPath, _previousDragToReorderIndexPath);
+      CGFloat adjust = ([currentPath compare:cell.indexPath] == NSOrderedDescending) ? 0 : 1;
+      
+      int irow = _previousDragToReorderIndexPath.row;
+      for(int i = _previousDragToReorderIndexPath.section; i < [self numberOfSections]; i++){
+        for(int j = irow; j < [self numberOfRowsInSection:i]; j++){
+          TUIFastIndexPath *path = [TUIFastIndexPath indexPathForRow:j inSection:i];
+          TUITableViewCell *displacedCell;
+          if((displacedCell = [self cellForRowAtIndexPath:path]) != nil){
+            CGRect frame = [self rectForRowAtIndexPath:path];
+            displacedCell.frame = CGRectMake(frame.origin.x, frame.origin.y + (cell.frame.size.height * adjust), frame.size.width, frame.size.height);
+          }
+          if([path isEqual:currentPath]){
+            goto done; // stop when we hit the current row
+          }
+        }
+        irow = 0;
+      }
+      
+    }
+    
+  }
+  
+done:
+  // note the current path
+  [_currentDragToReorderIndexPath release];
+  _currentDragToReorderIndexPath = [currentPath retain];
+  
+  // bring to front
+  [[cell superview] bringSubviewToFront:cell];
+  // move the cell
+  cell.frame = dest;
+  
+}
+
+@end
+

--- a/lib/UIKit/TUITableView+Cell.m
+++ b/lib/UIKit/TUITableView+Cell.m
@@ -134,39 +134,7 @@
       [TUIView beginAnimations:NSStringFromSelector(_cmd) context:NULL];
     }
     
-    /* UNRELIABLE, FASTER VERSION
-    // enumerate index paths between the previous and current paths.  these are the affected
-    // rows which need to be adjusted for the dragged row.
     [self enumerateIndexPathsFromIndexPath:fromIndexPath toIndexPath:toIndexPath withOptions:0 usingBlock:^(TUIFastIndexPath *indexPath, BOOL *stop) {
-      TUITableViewCell *displacedCell;
-      if((displacedCell = [self cellForRowAtIndexPath:indexPath]) != nil){
-        CGRect frame = [self rectForRowAtIndexPath:indexPath];
-        if(currentDragDirection == NSOrderedAscending){
-          if(relativeDirection == NSOrderedAscending){
-            // if we're moving up but we are above the dragged cell index, cells are adjusted down to swap
-            // places with the dragged cell
-            displacedCell.frame = CGRectMake(frame.origin.x, frame.origin.y - cell.frame.size.height, frame.size.width, frame.size.height);
-          }else{
-            // if we're moving up but we are below or at the dragged cell index, cells are returned to their
-            // original frame as they're passed
-            displacedCell.frame = frame;
-          }
-        }else if(currentDragDirection == NSOrderedDescending){
-          if(relativeDirection == NSOrderedDescending){
-            // if we're moving down but we are below the dragged cell index, cells are adjusted up to swap
-            // places with the dragged cell
-            displacedCell.frame = CGRectMake(frame.origin.x, frame.origin.y + cell.frame.size.height, frame.size.width, frame.size.height);
-          }else{
-            // if we're moving down but we are above or at the dragged cell index, cells are returned to their
-            // original frame as they're passed
-            displacedCell.frame = frame;
-          }
-        }
-      }
-    }];
-    */
-    
-    [self enumerateIndexPathsUsingBlock:^(TUIFastIndexPath *indexPath, BOOL *stop) {
       TUITableViewCell *displacedCell;
       if((displacedCell = [self cellForRowAtIndexPath:indexPath]) != nil){
         CGRect frame = [self rectForRowAtIndexPath:indexPath];

--- a/lib/UIKit/TUITableView+Cell.m
+++ b/lib/UIKit/TUITableView+Cell.m
@@ -121,9 +121,12 @@
   // note the previous path
   [_previousDragToReorderIndexPath release];
   _previousDragToReorderIndexPath = [_currentDragToReorderIndexPath retain];
+  _previousDragToReorderInsertionMethod = _currentDragToReorderInsertionMethod;
+  
   // note the current path
   [_currentDragToReorderIndexPath release];
   _currentDragToReorderIndexPath = [currentPath retain];
+  _currentDragToReorderInsertionMethod = insertMethod;
   
   // determine the current drag direction
   NSComparisonResult currentDragDirection = (_previousDragToReorderIndexPath != nil) ? [currentPath compare:_previousDragToReorderIndexPath] : NSOrderedSame;
@@ -138,8 +141,9 @@
   }else if(currentDragDirection == NSOrderedDescending){
     fromIndexPath = _previousDragToReorderIndexPath;
     toIndexPath = currentPath;
-  }else{
-    // same index path; nil
+  }else if(insertMethod != _previousDragToReorderInsertionMethod){
+    fromIndexPath = currentPath;
+    toIndexPath = currentPath;
   }
   
   // we now have the final destination index path.  if it's not nil, update surrounding

--- a/lib/UIKit/TUITableView+Cell.m
+++ b/lib/UIKit/TUITableView+Cell.m
@@ -75,6 +75,10 @@
       case TUITableViewInsertionMethodAfterIndex:
         frame = CGRectMake(frame.origin.x, frame.origin.y - cell.frame.size.height, frame.size.width, frame.size.height);
         break;
+      case TUITableViewInsertionMethodAtIndex:
+      default:
+        // do nothing. this case is just here to avoid complier complaints...
+        break;
     }
     
     // move the cell to its final frame and reload the table data to make sure all
@@ -202,14 +206,13 @@
   // we now have the final destination index path.  if it's not nil, update surrounding
   // cells to make room for the dragged cell
   if(currentPath != nil && fromIndexPath != nil && toIndexPath != nil){
-    NSComparisonResult relativeDirection = [currentPath compare:cell.indexPath];
     
     // begin animations
     if(animate){
       [TUIView beginAnimations:NSStringFromSelector(_cmd) context:NULL];
     }
     
-    for(int i = fromIndexPath.section; i <= toIndexPath.section; i++){
+    for(NSInteger i = fromIndexPath.section; i <= toIndexPath.section; i++){
       TUIView *headerView;
       if(currentPath.section < i && i <= cell.indexPath.section){
         // the current index path is above this section and this section is at or
@@ -236,7 +239,6 @@
     [self enumerateIndexPathsFromIndexPath:fromIndexPath toIndexPath:toIndexPath withOptions:0 usingBlock:^(TUIFastIndexPath *indexPath, BOOL *stop) {
       TUITableViewCell *displacedCell;
       if((displacedCell = [self cellForRowAtIndexPath:indexPath]) != nil){
-        TUIView *headerView = nil;
         CGRect frame = [self rectForRowAtIndexPath:indexPath];
         CGRect target;
         

--- a/lib/UIKit/TUITableView.h
+++ b/lib/UIKit/TUITableView.h
@@ -119,6 +119,10 @@ typedef enum {
 - (NSArray *)indexPathsForRowsInRect:(CGRect)rect;                              // returns nil if rect not valid 
 - (TUIFastIndexPath *)indexPathForRowAtPoint:(CGPoint)point;
 
+- (void)enumerateIndexPathsUsingBlock:(void (^)(TUIFastIndexPath *indexPath, BOOL *stop))block;
+- (void)enumerateIndexPathsWithOptions:(NSEnumerationOptions)options usingBlock:(void (^)(TUIFastIndexPath *indexPath, BOOL *stop))block;
+- (void)enumerateIndexPathsFromIndexPath:(TUIFastIndexPath *)fromIndexPath toIndexPath:(TUIFastIndexPath *)toIndexPath withOptions:(NSEnumerationOptions)options usingBlock:(void (^)(TUIFastIndexPath *indexPath, BOOL *stop))block;
+
 - (TUIView *)headerViewForSection:(NSInteger)section;
 - (TUITableViewCell *)cellForRowAtIndexPath:(TUIFastIndexPath *)indexPath;            // returns nil if cell is not visible or index path is out of range
 - (NSArray *)visibleCells; // no particular order

--- a/lib/UIKit/TUITableView.h
+++ b/lib/UIKit/TUITableView.h
@@ -44,8 +44,14 @@ typedef enum {
 - (void)tableView:(TUITableView *)tableView didSelectRowAtIndexPath:(TUIFastIndexPath *)indexPath; // happens on mouse down
 - (void)tableView:(TUITableView *)tableView didDeselectRowAtIndexPath:(TUIFastIndexPath *)indexPath;
 - (void)tableView:(TUITableView *)tableView didClickRowAtIndexPath:(TUIFastIndexPath *)indexPath withEvent:(NSEvent *)event; // happens on mouse up (can look at clickCount)
+
+// the following are good places to update or restore state (such as selection) when the table data reloads
 - (void)tableViewWillReloadData:(TUITableView *)tableView;
 - (void)tableViewDidReloadData:(TUITableView *)tableView;
+
+// the following are required to support dragging to reorder cells
+- (BOOL)tableView:(TUITableView *)tableView allowsReorderingOfRowAtIndexPath:(TUIFastIndexPath *)indexPath;
+- (TUIFastIndexPath *)tableView:(TUITableView *)tableView targetIndexPathForMoveFromRowAtIndexPath:(TUIFastIndexPath *)fromPath toProposedIndexPath:(TUIFastIndexPath *)proposedPath;
 
 @end
 
@@ -70,6 +76,11 @@ typedef enum {
 	TUIFastIndexPath            * _keepVisibleIndexPathForReload;
 	CGFloat                       _relativeOffsetForReload;
 	
+  TUIFastIndexPath            * _currentDragToReorderIndexPath;
+  TUIFastIndexPath            * _previousDragToReorderIndexPath;
+  TUIFastIndexPath            * _referenceDragToReorderIndexPath;
+	NSComparisonResult            _currentDragToReorderDirection;
+  
 	struct {
 		unsigned int animateSelectionChanges:1;
 		unsigned int forceSaveScrollPosition:1;
@@ -79,6 +90,7 @@ typedef enum {
 		unsigned int dataSourceNumberOfSectionsInTableView:1;
 		unsigned int delegateTableViewWillDisplayCellForRowAtIndexPath:1;
 	} _tableFlags;
+	
 }
 
 - (id)initWithFrame:(CGRect)frame style:(TUITableViewStyle)style;                // must specify style at creation. -initWithFrame: calls this with UITableViewStylePlain
@@ -106,6 +118,7 @@ typedef enum {
 - (NSIndexSet *)indexesOfSectionHeadersInRect:(CGRect)rect;
 - (TUIFastIndexPath *)indexPathForCell:(TUITableViewCell *)cell;                      // returns nil if cell is not visible
 - (NSArray *)indexPathsForRowsInRect:(CGRect)rect;                              // returns nil if rect not valid 
+- (TUIFastIndexPath *)indexPathForRowAtPoint:(CGPoint)point;
 
 - (TUITableViewCell *)cellForRowAtIndexPath:(TUIFastIndexPath *)indexPath;            // returns nil if cell is not visible or index path is out of range
 - (NSArray *)visibleCells; // no particular order

--- a/lib/UIKit/TUITableView.h
+++ b/lib/UIKit/TUITableView.h
@@ -119,6 +119,7 @@ typedef enum {
 - (NSArray *)indexPathsForRowsInRect:(CGRect)rect;                              // returns nil if rect not valid 
 - (TUIFastIndexPath *)indexPathForRowAtPoint:(CGPoint)point;
 
+- (TUIView *)headerViewForSection:(NSInteger)section;
 - (TUITableViewCell *)cellForRowAtIndexPath:(TUIFastIndexPath *)indexPath;            // returns nil if cell is not visible or index path is out of range
 - (NSArray *)visibleCells; // no particular order
 - (NSArray *)sortedVisibleCells; // top to bottom

--- a/lib/UIKit/TUITableView.h
+++ b/lib/UIKit/TUITableView.h
@@ -30,9 +30,9 @@ typedef enum {
 } TUITableViewScrollPosition;
 
 typedef enum {
-  TUITableViewInsertionMethodBeforeIndex  = -1,
-  TUITableViewInsertionMethodAtIndex      =  0,
-  TUITableViewInsertionMethodAfterIndex   =  1
+  TUITableViewInsertionMethodBeforeIndex  = NSOrderedAscending,
+  TUITableViewInsertionMethodAtIndex      = NSOrderedSame,
+  TUITableViewInsertionMethodAfterIndex   = NSOrderedDescending
 } TUITableViewInsertionMethod;
 
 @class TUITableViewCell;
@@ -82,8 +82,10 @@ typedef enum {
 	CGFloat                       _relativeOffsetForReload;
 	
   TUIFastIndexPath            * _currentDragToReorderIndexPath;
+  TUITableViewInsertionMethod   _currentDragToReorderInsertionMethod;
   TUIFastIndexPath            * _previousDragToReorderIndexPath;
-	NSComparisonResult            _currentDragToReorderDirection;
+  TUITableViewInsertionMethod   _previousDragToReorderInsertionMethod;
+  NSComparisonResult            _currentDragToReorderDirection;
   
 	struct {
 		unsigned int animateSelectionChanges:1;

--- a/lib/UIKit/TUITableView.h
+++ b/lib/UIKit/TUITableView.h
@@ -67,7 +67,7 @@ typedef enum {
 	NSArray                     * _sectionInfo;
 	
 	TUIView                     * _pullDownView;
-	TUIView							        *_headerView;
+	TUIView							        * _headerView;
 	
 	CGSize                        _lastSize;
 	CGFloat                       _contentHeight;
@@ -82,6 +82,10 @@ typedef enum {
 	TUIFastIndexPath            * _keepVisibleIndexPathForReload;
 	CGFloat                       _relativeOffsetForReload;
 	
+	// drag-to-reorder state
+  TUITableViewCell            * _dragToReorderCell;
+  CGPoint                       _currentDragToReorderLocation;
+  CGPoint                       _currentDragToReorderMouseOffset;
   TUIFastIndexPath            * _currentDragToReorderIndexPath;
   TUITableViewInsertionMethod   _currentDragToReorderInsertionMethod;
   TUIFastIndexPath            * _previousDragToReorderIndexPath;

--- a/lib/UIKit/TUITableView.h
+++ b/lib/UIKit/TUITableView.h
@@ -97,6 +97,7 @@ typedef enum {
 - (NSInteger)numberOfRowsInSection:(NSInteger)section;
 
 - (CGRect)rectForHeaderOfSection:(NSInteger)section;
+- (CGRect)rectForSection:(NSInteger)section;
 - (CGRect)rectForRowAtIndexPath:(TUIFastIndexPath *)indexPath;
 
 - (NSIndexSet *)indexesOfSectionsInRect:(CGRect)rect;

--- a/lib/UIKit/TUITableView.h
+++ b/lib/UIKit/TUITableView.h
@@ -29,6 +29,12 @@ typedef enum {
 	TUITableViewScrollPositionToVisible, // currently the only supported arg
 } TUITableViewScrollPosition;
 
+typedef enum {
+  TUITableViewInsertionMethodBeforeIndex  = -1,
+  TUITableViewInsertionMethodAtIndex      =  0,
+  TUITableViewInsertionMethodAfterIndex   =  1
+} TUITableViewInsertionMethod;
+
 @class TUITableViewCell;
 @protocol TUITableViewDataSource;
 
@@ -117,6 +123,7 @@ typedef enum {
 - (TUIFastIndexPath *)indexPathForCell:(TUITableViewCell *)cell;                      // returns nil if cell is not visible
 - (NSArray *)indexPathsForRowsInRect:(CGRect)rect;                              // returns nil if rect not valid 
 - (TUIFastIndexPath *)indexPathForRowAtPoint:(CGPoint)point;
+- (NSInteger)indexOfSectionWithHeaderAtPoint:(CGPoint)point;
 
 - (void)enumerateIndexPathsUsingBlock:(void (^)(TUIFastIndexPath *indexPath, BOOL *stop))block;
 - (void)enumerateIndexPathsWithOptions:(NSEnumerationOptions)options usingBlock:(void (^)(TUIFastIndexPath *indexPath, BOOL *stop))block;

--- a/lib/UIKit/TUITableView.h
+++ b/lib/UIKit/TUITableView.h
@@ -85,7 +85,6 @@ typedef enum {
   TUITableViewInsertionMethod   _currentDragToReorderInsertionMethod;
   TUIFastIndexPath            * _previousDragToReorderIndexPath;
   TUITableViewInsertionMethod   _previousDragToReorderInsertionMethod;
-  NSComparisonResult            _currentDragToReorderDirection;
   
 	struct {
 		unsigned int animateSelectionChanges:1;

--- a/lib/UIKit/TUITableView.h
+++ b/lib/UIKit/TUITableView.h
@@ -44,6 +44,8 @@ typedef enum {
 - (void)tableView:(TUITableView *)tableView didSelectRowAtIndexPath:(TUIFastIndexPath *)indexPath; // happens on mouse down
 - (void)tableView:(TUITableView *)tableView didDeselectRowAtIndexPath:(TUIFastIndexPath *)indexPath;
 - (void)tableView:(TUITableView *)tableView didClickRowAtIndexPath:(TUIFastIndexPath *)indexPath withEvent:(NSEvent *)event; // happens on mouse up (can look at clickCount)
+- (void)tableViewWillReloadData:(TUITableView *)tableView;
+- (void)tableViewDidReloadData:(TUITableView *)tableView;
 
 @end
 

--- a/lib/UIKit/TUITableView.h
+++ b/lib/UIKit/TUITableView.h
@@ -78,7 +78,6 @@ typedef enum {
 	
   TUIFastIndexPath            * _currentDragToReorderIndexPath;
   TUIFastIndexPath            * _previousDragToReorderIndexPath;
-  TUIFastIndexPath            * _referenceDragToReorderIndexPath;
 	NSComparisonResult            _currentDragToReorderDirection;
   
 	struct {

--- a/lib/UIKit/TUITableView.h
+++ b/lib/UIKit/TUITableView.h
@@ -49,8 +49,7 @@ typedef enum {
 - (void)tableViewWillReloadData:(TUITableView *)tableView;
 - (void)tableViewDidReloadData:(TUITableView *)tableView;
 
-// the following are required to support dragging to reorder cells
-- (BOOL)tableView:(TUITableView *)tableView allowsReorderingOfRowAtIndexPath:(TUIFastIndexPath *)indexPath;
+// the following is optional for row reordering
 - (TUIFastIndexPath *)tableView:(TUITableView *)tableView targetIndexPathForMoveFromRowAtIndexPath:(TUIFastIndexPath *)fromPath toProposedIndexPath:(TUIFastIndexPath *)proposedPath;
 
 @end
@@ -163,6 +162,10 @@ typedef enum {
 @optional
 
 - (TUITableViewCell *)tableView:(TUITableView *)tableView headerViewForSection:(NSInteger)section;
+
+// the following are required to support row reordering
+- (BOOL)tableView:(TUITableView *)tableView canMoveRowAtIndexPath:(TUIFastIndexPath *)indexPath;
+- (void)tableView:(TUITableView *)tableView moveRowAtIndexPath:(TUIFastIndexPath *)fromIndexPath toIndexPath:(TUIFastIndexPath *)toIndexPath;
 
 /**
  Default is 1 if not implemented

--- a/lib/UIKit/TUITableView.m
+++ b/lib/UIKit/TUITableView.m
@@ -950,7 +950,8 @@ static NSInteger SortCells(TUITableViewCell *a, TUITableViewCell *b, void *ctx)
 - (void)_makeRowAtIndexPathFirstResponder:(TUIFastIndexPath *)indexPath
 {
 	TUITableViewCell *cell = [self cellForRowAtIndexPath:indexPath];
-	if(cell) {
+	// only cells that accept first responder should be made first responder
+	if(cell && [cell acceptsFirstResponder]) {
 		[self.nsWindow makeFirstResponderIfNotAlreadyInResponderChain:cell];
 	} else {
 		[_indexPathShouldBeFirstResponder release];

--- a/lib/UIKit/TUITableView.m
+++ b/lib/UIKit/TUITableView.m
@@ -659,6 +659,12 @@ static NSInteger SortCells(TUITableViewCell *a, TUITableViewCell *b, void *ctx)
 
 - (void)reloadData
 {
+  
+  // notify our delegate we're about to reload the table
+  if(self.delegate != nil && [self.delegate respondsToSelector:@selector(tableViewWillReloadData:)]){
+    [self.delegate tableViewWillReloadData:self];
+  }
+  
 	// need to recycle all visible cells, have them be regenerated on layoutSubviews
 	// because the same cells might have different content
 	for(TUIFastIndexPath *i in _visibleItems) {
@@ -672,6 +678,12 @@ static NSInteger SortCells(TUITableViewCell *a, TUITableViewCell *b, void *ctx)
 	_sectionInfo = nil; // will be regenerated on next layout
 	
 	[self layoutSubviews];
+	
+  // notify our delegate the table view has been reloaded
+  if(self.delegate != nil && [self.delegate respondsToSelector:@selector(tableViewDidReloadData:)]){
+    [self.delegate tableViewDidReloadData:self];
+  }
+  
 }
 
 - (void)layoutSubviews

--- a/lib/UIKit/TUITableView.m
+++ b/lib/UIKit/TUITableView.m
@@ -460,6 +460,52 @@ static NSInteger SortCells(TUITableViewCell *a, TUITableViewCell *b, void *ctx)
 	return nil;
 }
 
+/**
+ * @brief Enumerate index paths
+ * @see #enumerateIndexPathsFromIndexPath:toIndexPath:withOptions:usingBlock:
+ */
+- (void)enumerateIndexPathsUsingBlock:(void (^)(TUIFastIndexPath *indexPath, BOOL *stop))block {
+  [self enumerateIndexPathsFromIndexPath:nil toIndexPath:nil withOptions:0 usingBlock:block];
+}
+
+/**
+ * @brief Enumerate index paths
+ * @see #enumerateIndexPathsFromIndexPath:toIndexPath:withOptions:usingBlock:
+ */
+- (void)enumerateIndexPathsWithOptions:(NSEnumerationOptions)options usingBlock:(void (^)(TUIFastIndexPath *indexPath, BOOL *stop))block {
+  [self enumerateIndexPathsFromIndexPath:nil toIndexPath:nil withOptions:options usingBlock:block];
+}
+
+/**
+ * @brief Enumerate index paths
+ * 
+ * The provided block is repeatedly invoked with each valid index path between
+ * the specified bounds.  Both bounding index paths are inclusive.
+ * 
+ * @param fromIndexPath the index path to begin enumerating at or nil to begin at the first index path
+ * @param toIndexPath the index path to stop enumerating at or nil to stop at the last index path
+ * @param options enumeration options (not currently supported; pass 0)
+ * @param block the block to enumerate with
+ */
+- (void)enumerateIndexPathsFromIndexPath:(TUIFastIndexPath *)fromIndexPath toIndexPath:(TUIFastIndexPath *)toIndexPath withOptions:(NSEnumerationOptions)options usingBlock:(void (^)(TUIFastIndexPath *indexPath, BOOL *stop))block {
+  NSInteger sectionLowerBound = (fromIndexPath != nil) ? fromIndexPath.section : 0;
+  NSInteger sectionUpperBound = (toIndexPath != nil) ? toIndexPath.section : [self numberOfSections] - 1;
+  NSInteger rowLowerBound = (fromIndexPath != nil) ? fromIndexPath.row : 0;
+  NSInteger rowUpperBound = (toIndexPath != nil) ? toIndexPath.row : -1;
+  
+  int irow = rowLowerBound; // start at the lower bound row for the first iteration...
+  for(int i = sectionLowerBound; i < [self numberOfSections] && i <= sectionUpperBound /* inclusive */; i++){
+    NSInteger rowCount = [self numberOfRowsInSection:i];
+    for(int j = irow; j < rowCount && j <= ((rowUpperBound < 0 || i < sectionUpperBound) ? rowCount - 1 : rowUpperBound); j++){
+      BOOL stop = FALSE;
+      block([TUIFastIndexPath indexPathForRow:j inSection:i], &stop);
+      if(stop) return;
+    }
+    irow = 0; // ...then use zero for subsequent iterations
+  }
+  
+}
+
 - (TUIFastIndexPath *)_topVisibleIndexPath
 {
 	TUIFastIndexPath *topVisibleIndex = nil;

--- a/lib/UIKit/TUITableView.m
+++ b/lib/UIKit/TUITableView.m
@@ -522,10 +522,10 @@ static NSInteger SortCells(TUITableViewCell *a, TUITableViewCell *b, void *ctx)
   NSInteger rowLowerBound = (fromIndexPath != nil) ? fromIndexPath.row : 0;
   NSInteger rowUpperBound = (toIndexPath != nil) ? toIndexPath.row : -1;
   
-  int irow = rowLowerBound; // start at the lower bound row for the first iteration...
-  for(int i = sectionLowerBound; i < [self numberOfSections] && i <= sectionUpperBound /* inclusive */; i++){
+  NSInteger irow = rowLowerBound; // start at the lower bound row for the first iteration...
+  for(NSInteger i = sectionLowerBound; i < [self numberOfSections] && i <= sectionUpperBound /* inclusive */; i++){
     NSInteger rowCount = [self numberOfRowsInSection:i];
-    for(int j = irow; j < rowCount && j <= ((rowUpperBound < 0 || i < sectionUpperBound) ? rowCount - 1 : rowUpperBound) /* inclusive */; j++){
+    for(NSInteger j = irow; j < rowCount && j <= ((rowUpperBound < 0 || i < sectionUpperBound) ? rowCount - 1 : rowUpperBound) /* inclusive */; j++){
       BOOL stop = FALSE;
       block([TUIFastIndexPath indexPathForRow:j inSection:i], &stop);
       if(stop) return;

--- a/lib/UIKit/TUITableView.m
+++ b/lib/UIKit/TUITableView.m
@@ -461,6 +461,35 @@ static NSInteger SortCells(TUITableViewCell *a, TUITableViewCell *b, void *ctx)
 }
 
 /**
+ * @brief Obtain the index of a section whose header is at the specified point
+ * 
+ * If the point is not valid or no header exists at that point, a negative value
+ * is returned.
+ * 
+ * @param point location in the table view
+ * @return index of the section whose header is at @p point
+ */
+- (NSInteger)indexOfSectionWithHeaderAtPoint:(CGPoint)point {
+  
+	NSInteger sectionIndex = 0;
+  for(TUITableViewSection *section in _sectionInfo){
+    TUIView *headerView;
+    if((headerView = section.headerView) != nil){
+      CGFloat offset = [section sectionOffset];
+      CGFloat height = [section headerHeight];
+      CGFloat y = _contentHeight - offset - height;
+      CGRect frame = CGRectMake(0, y, self.bounds.size.width, height);
+      if(CGRectContainsPoint(frame, point)){
+        return sectionIndex;
+      }
+    }
+    sectionIndex++;
+  }
+	
+	return -1;
+}
+
+/**
  * @brief Enumerate index paths
  * @see #enumerateIndexPathsFromIndexPath:toIndexPath:withOptions:usingBlock:
  */

--- a/lib/UIKit/TUITableView.m
+++ b/lib/UIKit/TUITableView.m
@@ -791,6 +791,8 @@ static NSInteger SortCells(TUITableViewCell *a, TUITableViewCell *b, void *ctx)
 		[self _enqueueReusableCell:cell];
 		[cell removeFromSuperview];
 	}
+	
+	// clear visible cells
 	[_visibleItems removeAllObjects];
 	
 	// remove any visible headers, they should be re-added when the table is laid out
@@ -801,7 +803,7 @@ static NSInteger SortCells(TUITableViewCell *a, TUITableViewCell *b, void *ctx)
 	  }
 	}
 	
-	// clear visible sections
+	// clear visible section headers
 	[_visibleSectionHeaders removeAllIndexes];
 	
 	[_sectionInfo release];

--- a/lib/UIKit/TUITableView.m
+++ b/lib/UIKit/TUITableView.m
@@ -496,7 +496,7 @@ static NSInteger SortCells(TUITableViewCell *a, TUITableViewCell *b, void *ctx)
   int irow = rowLowerBound; // start at the lower bound row for the first iteration...
   for(int i = sectionLowerBound; i < [self numberOfSections] && i <= sectionUpperBound /* inclusive */; i++){
     NSInteger rowCount = [self numberOfRowsInSection:i];
-    for(int j = irow; j < rowCount && j <= ((rowUpperBound < 0 || i < sectionUpperBound) ? rowCount - 1 : rowUpperBound); j++){
+    for(int j = irow; j < rowCount && j <= ((rowUpperBound < 0 || i < sectionUpperBound) ? rowCount - 1 : rowUpperBound) /* inclusive */; j++){
       BOOL stop = FALSE;
       block([TUIFastIndexPath indexPathForRow:j inSection:i], &stop);
       if(stop) return;

--- a/lib/UIKit/TUITableView.m
+++ b/lib/UIKit/TUITableView.m
@@ -174,7 +174,6 @@ typedef struct {
 	[_pullDownView release];
 	[_currentDragToReorderIndexPath release];
 	[_previousDragToReorderIndexPath release];
-	[_referenceDragToReorderIndexPath release];
 	[super dealloc];
 }
 

--- a/lib/UIKit/TUITableView.m
+++ b/lib/UIKit/TUITableView.m
@@ -853,6 +853,10 @@ static NSInteger SortCells(TUITableViewCell *a, TUITableViewCell *b, void *ctx)
 		[cell removeFromSuperview];
 	}
 	
+	// if we have a dragged cell, clear it
+	[_dragToReorderCell release];
+	_dragToReorderCell = nil;
+	
 	// clear visible cells
 	[_visibleItems removeAllObjects];
 	

--- a/lib/UIKit/TUITableView.m
+++ b/lib/UIKit/TUITableView.m
@@ -228,6 +228,18 @@ typedef struct {
 	return CGRectZero;
 }
 
+- (CGRect)rectForSection:(NSInteger)section
+{
+	if(section >= 0 && section < [_sectionInfo count]){
+		TUITableViewSection *s = [_sectionInfo objectAtIndex:section];
+		CGFloat offset = [s sectionOffset];
+		CGFloat height = [s sectionHeight];
+		CGFloat y = _contentHeight - offset - height;
+		return CGRectMake(0, y, self.bounds.size.width, height);
+	}
+	return CGRectZero;
+}
+
 - (CGRect)rectForRowAtIndexPath:(TUIFastIndexPath *)indexPath
 {
 	NSInteger section = indexPath.section;
@@ -357,7 +369,7 @@ static NSInteger SortCells(TUITableViewCell *a, TUITableViewCell *b, void *ctx)
 	NSMutableIndexSet *indexes = [[NSMutableIndexSet alloc] init];
 	
 	for(int i = 0; i < [_sectionInfo count]; i++) {
-		if(CGRectIntersectsRect([self rectForHeaderOfSection:i], rect)){
+		if(CGRectIntersectsRect([self rectForSection:i], rect)){
 			[indexes addIndex:i];
 		}
 	}

--- a/lib/UIKit/TUITableView.m
+++ b/lib/UIKit/TUITableView.m
@@ -316,6 +316,22 @@ typedef struct {
 	return nil;
 }
 
+/**
+ * @brief Obtain the header view for the specified section
+ * 
+ * If the section has no header, nil is returned.
+ * 
+ * @param section the section
+ * @return section header
+ */
+- (TUIView *)headerViewForSection:(NSInteger)section {
+  if(section >= 0 && section < [_sectionInfo count]){
+    return [(TUITableViewSection *)[_sectionInfo objectAtIndex:section] headerView];
+  }else{
+    return nil;
+  }
+}
+
 - (TUITableViewCell *)cellForRowAtIndexPath:(TUIFastIndexPath *)indexPath // returns nil if cell is not visible or index path is out of range
 {
 	return [_visibleItems objectForKey:indexPath];
@@ -701,6 +717,17 @@ static NSInteger SortCells(TUITableViewCell *a, TUITableViewCell *b, void *ctx)
 		[cell removeFromSuperview];
 	}
 	[_visibleItems removeAllObjects];
+	
+	// remove any visible headers, they should be re-added when the table is laid out
+	for(TUITableViewSection *section in _sectionInfo){
+	  TUIView *headerView;
+	  if((headerView = [section headerView]) != nil){
+	    [headerView removeFromSuperview];
+	  }
+	}
+	
+	// clear visible sections
+	[_visibleSectionHeaders removeAllIndexes];
 	
 	[_sectionInfo release];
 	_sectionInfo = nil; // will be regenerated on next layout

--- a/lib/UIKit/TUITableView.m
+++ b/lib/UIKit/TUITableView.m
@@ -172,6 +172,9 @@ typedef struct {
 	[_indexPathShouldBeFirstResponder release];
 	[_keepVisibleIndexPathForReload release];
 	[_pullDownView release];
+	[_currentDragToReorderIndexPath release];
+	[_previousDragToReorderIndexPath release];
+	[_referenceDragToReorderIndexPath release];
 	[super dealloc];
 }
 
@@ -414,6 +417,32 @@ static NSInteger SortCells(TUITableViewCell *a, TUITableViewCell *b, void *ctx)
 		++sectionIndex;
 	}
 	return indexPaths;
+}
+
+/**
+ * @brief Obtain the index path of the row at the specified point
+ * 
+ * If the point is not valid or no row exists at that point, nil is
+ * returned.
+ * 
+ * @param point location in the table view
+ * @return index path of the row at @p point
+ */
+- (TUIFastIndexPath *)indexPathForRowAtPoint:(CGPoint)point {
+  
+	NSInteger sectionIndex = 0;
+  for(TUITableViewSection *section in _sectionInfo){
+    for(NSInteger row = 0; row < [section numberOfRows]; row++){
+      TUIFastIndexPath *indexPath = [TUIFastIndexPath indexPathForRow:row inSection:sectionIndex];
+      CGRect cellRect = [self rectForRowAtIndexPath:indexPath];
+      if(CGRectContainsPoint(cellRect, point)){
+        return indexPath;
+      }
+    }
+		++sectionIndex;
+  }
+	
+	return nil;
 }
 
 - (TUIFastIndexPath *)_topVisibleIndexPath

--- a/lib/UIKit/TUITableView.m
+++ b/lib/UIKit/TUITableView.m
@@ -770,7 +770,10 @@ static NSInteger SortCells(TUITableViewCell *a, TUITableViewCell *b, void *ctx)
 			[self addSubview:cell];
 			
 			if([_indexPathShouldBeFirstResponder isEqual:i]) {
-				[self.nsWindow makeFirstResponderIfNotAlreadyInResponderChain:cell withFutureRequestToken:_futureMakeFirstResponderToken];
+			  // only make cells first responder if they accept it
+			  if([cell acceptsFirstResponder]){
+			    [self.nsWindow makeFirstResponderIfNotAlreadyInResponderChain:cell withFutureRequestToken:_futureMakeFirstResponderToken];
+			  }
 				[_indexPathShouldBeFirstResponder release];
 				_indexPathShouldBeFirstResponder = nil;
 			}

--- a/lib/UIKit/TUITableViewCell.h
+++ b/lib/UIKit/TUITableViewCell.h
@@ -25,12 +25,15 @@ typedef enum {
 
 @interface TUITableViewCell : TUIView
 {
-	NSString *_reuseIdentifier;
+  
+  NSString  * _reuseIdentifier;
+  CGPoint     _mouseOffset;
 	
 	struct {
 		unsigned int highlighted:1;
 		unsigned int selected:1;
 	} _tableViewCellFlags;
+	
 }
 
 - (id)initWithStyle:(TUITableViewCellStyle)style reuseIdentifier:(NSString *)reuseIdentifier;

--- a/lib/UIKit/TUITableViewCell.m
+++ b/lib/UIKit/TUITableViewCell.m
@@ -73,6 +73,13 @@
 	return NO;
 }
 
+/**
+ * @brief Accept first responder by default
+ */
+-(BOOL)acceptsFirstResponder {
+  return TRUE;
+}
+
 - (void)mouseDown:(NSEvent *)event
 {
   // note the initial mouse location for dragging

--- a/lib/UIKit/TUITableViewCell.m
+++ b/lib/UIKit/TUITableViewCell.m
@@ -16,6 +16,7 @@
 
 #import "TUITableViewCell.h"
 #import "TUITableView.h"
+#import "TUITableView+Cell.h"
 
 @implementation TUITableViewCell
 
@@ -74,16 +75,35 @@
 
 - (void)mouseDown:(NSEvent *)event
 {
+  
+  // note the initial mouse location for dragging
+  _mouseOffset = [self localPointForLocationInWindow:[event locationInWindow]];
+  // notify our table view of the event
+  [self.tableView __mouseDownInCell:self offset:_mouseOffset event:event];
+  
 	TUITableView *tableView = self.tableView;
 	[tableView selectRowAtIndexPath:self.indexPath animated:tableView.animateSelectionChanges scrollPosition:TUITableViewScrollPositionNone];
 	[super mouseDown:event]; // may make the text renderer first responder, so we want to do the selection before this
+	
 	_tableViewCellFlags.highlighted = 1;
 	[self setNeedsDisplay];
+	
+}
+
+/**
+ * @brief The table cell was dragged
+ */
+-(void)mouseDragged:(NSEvent *)event {
+  // notify our table view of the event
+  [self.tableView __mouseDraggedCell:self offset:_mouseOffset event:event];
 }
 
 - (void)mouseUp:(NSEvent *)event
 {
 	[super mouseUp:event];
+  // notify our table view of the event
+  [self.tableView __mouseUpInCell:self offset:_mouseOffset event:event];
+  
 	_tableViewCellFlags.highlighted = 0;
 	[self setNeedsDisplay];
 	


### PR DESCRIPTION
Drag-to-reorder rows support is added to TUITableView in a manner similar to UITableView.  To use this functionality, a table's data source should implement the new methods:

``` objc
- (BOOL)tableView:(TUITableView *)tableView canMoveRowAtIndexPath:(TUIFastIndexPath *)indexPath;
- (void)tableView:(TUITableView *)tableView moveRowAtIndexPath:(TUIFastIndexPath *)fromIndexPath toIndexPath:(TUIFastIndexPath *)toIndexPath;
```

...and optionally, to constrain where rows may be moved, the table's delegate can implement:

``` objc
- (TUIFastIndexPath *)tableView:(TUITableView *)tableView targetIndexPathForMoveFromRowAtIndexPath:(TUIFastIndexPath *)fromPath toProposedIndexPath:(TUIFastIndexPath *)proposedPath;
```

I've added a new category to TUITableView (Cell) which exposes some "internal" methods of the table view that cells need to have access to due to the close relationship between these classes.  Specifically, cells can use these methods to forward mouse events to the table so that the table can do something with them (in this case, handle dragging).

In order to allow a table to automatically scroll content into view when a cell is dragged to the top or bottom of the viewport, I've made some small changes to TUIScrollView as well.  Specifically, the following methods are added which provide this kind of scrolling:

``` objc
- (void)beginContinuousScrollForDragAtPoint:(CGPoint)dragLocation animated:(BOOL)animated;
- (void)endContinuousScrollAnimated:(BOOL)animated;
```

...via the addition of the new animation mode `AnimationModeScrollContinuous`.  Due to the highly specific nature of this kind of scrolling, maybe these methods should be private, but I didn't want to reorganize TUIScrollView too much.

The example project has also been updated to demonstrate drag-to-reorder, however, since there isn't a "real" model and cells are just assigned a label corresponding to their index, **when the moved cell is dropped, the table will revert immediately back to its original state**.  This is because visible cells are laid out again immediately after the operation completes and get re-assigned their index-based label.

Other miscellaneous updates:
- Adding table will/did reload delegate methods
- Fixes incorrect geometry in TUITableView -indexesOfSectionsInRect:
- Adding -rectForSection: method in TUITableView
- Adding index path enumeration methods to TUITableView
