### PR TITLE
Use contentInset in TUITableView & fix view remove/re-add bug

### DIFF
--- a/lib/UIKit/TUINSView.m
+++ b/lib/UIKit/TUINSView.m
@@ -131,7 +131,8 @@
 	}
 }
 
-- (void)viewDidMoveToWindow {
+- (void)viewDidMoveToWindow
+{
 	if(self.window != nil && rootView.layer.superlayer != [self layer]) {
 		[[self layer] addSublayer:rootView.layer];
 	}

--- a/lib/UIKit/TUINSView.m
+++ b/lib/UIKit/TUINSView.m
@@ -131,6 +131,12 @@
 	}
 }
 
+- (void)viewDidMoveToWindow {
+	if(self.window != nil && rootView.layer.superlayer != [self layer]) {
+		[[self layer] addSublayer:rootView.layer];
+	}
+}
+
 - (TUIView *)viewForLocalPoint:(NSPoint)p
 {
 	return [rootView hitTest:p withEvent:nil];

--- a/lib/UIKit/TUITableView.m
+++ b/lib/UIKit/TUITableView.m
@@ -255,7 +255,7 @@ typedef struct {
 	NSMutableArray *sections = [NSMutableArray arrayWithCapacity:numberOfSections];
 	
 	int s;
-	CGFloat offset = [_headerView bounds].size.height;
+	CGFloat offset = [_headerView bounds].size.height - self.contentInset.top;
 	for(s = 0; s < numberOfSections; ++s) {
 		TUITableViewSection *section = [[TUITableViewSection alloc] initWithNumberOfRows:[_dataSource tableView:self numberOfRowsInSection:s] sectionIndex:s tableView:self];
 		[section _setupRowHeights];
@@ -265,7 +265,7 @@ typedef struct {
 		[section release];
 	}
 	
-	_contentHeight = offset;
+	_contentHeight = offset - self.contentInset.bottom;
 	
 	return sections;
 }


### PR DESCRIPTION
The first part is pretty self-explanatory.

The second part fixes #39. We had this same problem with Chameleon... When the layer-backed view is removed from its window, its view-backing layer removes all its sublayers. So when the view gets moved back to a window, we need to re-add `rootView`'s layer to our view-backing layer. Kinda gross side affect of layer-backed views.
