### PR TITLE
Clip to bounds, not the dirty rect

### DIFF
--- a/lib/UIKit/TUITextView.m
+++ b/lib/UIKit/TUITextView.m
@@ -204,7 +204,7 @@ static CAAnimation *ThrobAnimation()
 	
 	if(doMask) {
 		CGContextSaveGState(ctx);
-		CGContextClipToRoundRect(ctx, rect, floor(rect.size.height / 2));
+		CGContextClipToRoundRect(ctx, self.bounds, floor(rect.size.height / 2));
 	}
 	
 	[renderer draw];


### PR DESCRIPTION
Fixes a bug I introduced with the text renderer dirty rect stuff. It would cause the text view not to draw when the cursor was anywhere but at the end of the string.
