### PR TITLE
Call super for -rightMouseDown: so that we get sent -menuForEvent: for two-finger taps

### DIFF
--- a/lib/UIKit/TUINSView.m
+++ b/lib/UIKit/TUINSView.m
@@ -257,6 +257,7 @@
 	_trackingView = [[self viewForEvent:event] retain];
 	[_trackingView rightMouseDown:event];
 	[TUITooltipWindow endTooltip];
+	[super rightMouseDown:event]; // we need to send this up the responder chain so that -menuForEvent: will get called for two-finger taps
 }
 
 - (void)rightMouseUp:(NSEvent *)event


### PR DESCRIPTION
I'm not sure what implications this might have for Twitter for Mac, but I found this was necessary in order for `-menuForEvent:` to get called for two-finger taps.
