### PR TITLE
Commented out a category method that was unprefixed, unused, and just called the prefixed version

### DIFF
--- a/lib/UIKit/TUIStringDrawing.h
+++ b/lib/UIKit/TUIStringDrawing.h
@@ -38,7 +38,7 @@
 
 #if TARGET_OS_MAC
 // for ABRowView
-- (CGSize)drawInRect:(CGRect)rect withFont:(TUIFont *)font lineBreakMode:(TUILineBreakMode)lineBreakMode alignment:(TUITextAlignment)alignment;
+//- (CGSize)drawInRect:(CGRect)rect withFont:(TUIFont *)font lineBreakMode:(TUILineBreakMode)lineBreakMode alignment:(TUITextAlignment)alignment;
 #endif
 
 - (CGSize)ab_drawInRect:(CGRect)rect color:(TUIColor *)color font:(TUIFont *)font;

--- a/lib/UIKit/TUIStringDrawing.m
+++ b/lib/UIKit/TUIStringDrawing.m
@@ -83,10 +83,10 @@
 	return [s ab_sizeConstrainedToSize:size];
 }
 
-- (CGSize)drawInRect:(CGRect)rect withFont:(TUIFont *)font lineBreakMode:(TUILineBreakMode)lineBreakMode alignment:(TUITextAlignment)alignment
-{
-	return [self ab_drawInRect:rect withFont:font lineBreakMode:lineBreakMode alignment:alignment];
-}
+//- (CGSize)drawInRect:(CGRect)rect withFont:(TUIFont *)font lineBreakMode:(TUILineBreakMode)lineBreakMode alignment:(TUITextAlignment)alignment
+//{
+//	return [self ab_drawInRect:rect withFont:font lineBreakMode:lineBreakMode alignment:alignment];
+//}
 
 #endif
 


### PR DESCRIPTION
I'll throw this one out there to see what you think. I assume it's in there for Twitter for Mac legacy reasons, but it was causing problems with another category method of the same name. And in the end, it seems pretty pointless for public consumption.
