### PR TITLE
Fixed 2 minor issues in the README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,10 +45,11 @@ There are many places where TwUI could be improved:
 # Documentation
 
 You can generate documentation with [doxygen](http://www.doxygen.org). Install it, and then run:
-> cd docs
-> doxygen
 
-Documentation is a work in progress, but the API will be familiar if you have used UIKit.  (TODO: [appledoc](http://www.gentlebytes.com/home/appledocapp/) looks very cool, moving to that might be nice).
+    cd docs
+    doxygen
+
+Documentation is a work in progress, but the API will be familiar if you have used UIKit.  (TODO: [appledoc](http://gentlebytes.com/appledoc/) looks very cool, moving to that might be nice).
 
 TwUI has a mailing list, subscribe by sending an email to <twui@librelist.com>.
 


### PR DESCRIPTION
Fixed:
- Erroneous format on code block for `doxygen` docs generation.
- Incorrect link for appledoc
