### PR TITLE
Clear context after changing context scale

### DIFF
--- a/lib/UIKit/TUIView.m
+++ b/lib/UIKit/TUIView.m
@@ -310,8 +310,8 @@ else CGContextSetRGBFillColor(context, 1, 0, 0, 0.3); CGContextFillRect(context,
 	TUIGraphicsPushContext(context); \
 	CGFloat scale = [self.layer respondsToSelector:@selector(contentsScale)] ? self.layer.contentsScale : 1.0f; \
 	CGContextScaleCTM(context, scale, scale); \
-    if(_viewFlags.clearsContextBeforeDrawing) \
-        CGContextClearRect(context, b); \
+	if(_viewFlags.clearsContextBeforeDrawing) \
+		CGContextClearRect(context, b); \
 	CGContextSetAllowsAntialiasing(context, true); \
 	CGContextSetShouldAntialias(context, true); \
 	CGContextSetShouldSmoothFonts(context, !_viewFlags.disableSubpixelTextRendering);

--- a/lib/UIKit/TUIView.m
+++ b/lib/UIKit/TUIView.m
@@ -308,10 +308,10 @@ else CGContextSetRGBFillColor(context, 1, 0, 0, 0.3); CGContextFillRect(context,
 	CGRect b = self.bounds; \
 	CGContextRef context = [self _CGContext]; \
 	TUIGraphicsPushContext(context); \
-	if(_viewFlags.clearsContextBeforeDrawing) \
-		CGContextClearRect(context, b); \
 	CGFloat scale = [self.layer respondsToSelector:@selector(contentsScale)] ? self.layer.contentsScale : 1.0f; \
 	CGContextScaleCTM(context, scale, scale); \
+    if(_viewFlags.clearsContextBeforeDrawing) \
+        CGContextClearRect(context, b); \
 	CGContextSetAllowsAntialiasing(context, true); \
 	CGContextSetShouldAntialias(context, true); \
 	CGContextSetShouldSmoothFonts(context, !_viewFlags.disableSubpixelTextRendering);


### PR DESCRIPTION
Otherwise we get strange artifacts when re-drawing TUILabels on Retina displays.
