### PR TITLE
Fixing scroll knob visibility issue when indicator visibility is set to show scroll knobs while scrolling

### DIFF
--- a/lib/UIKit/TUIScrollView.m
+++ b/lib/UIKit/TUIScrollView.m
@@ -367,7 +367,7 @@ enum {
       vEffectiveVisible = _verticalScrollKnob.flashing;
       break;
     case TUIScrollViewIndicatorVisibleWhenScrolling:
-	  vEffectiveVisible = vVisible && (_scrollViewFlags.animationMode != AnimationModeNone || _verticalScrollKnob.flashing);
+	  vEffectiveVisible = vVisible && (_scrollViewFlags.animationMode != AnimationModeNone || _verticalScrollKnob.flashing || self.isDragging);
       break;
     case TUIScrollViewIndicatorVisibleWhenMouseInside:
       vEffectiveVisible = vVisible && (_scrollViewFlags.animationMode != AnimationModeNone || _scrollViewFlags.mouseInside || _scrollViewFlags.mouseDownInScrollKnob || _verticalScrollKnob.flashing);
@@ -383,7 +383,7 @@ enum {
       hEffectiveVisible = FALSE;
       break;
     case TUIScrollViewIndicatorVisibleWhenScrolling:
-      hEffectiveVisible = vVisible && (_scrollViewFlags.animationMode != AnimationModeNone || _horizontalScrollKnob.flashing);
+      hEffectiveVisible = vVisible && (_scrollViewFlags.animationMode != AnimationModeNone || _horizontalScrollKnob.flashing || self.isDragging);
       break;
     case TUIScrollViewIndicatorVisibleWhenMouseInside:
       hEffectiveVisible = vVisible && (_scrollViewFlags.animationMode != AnimationModeNone || _scrollViewFlags.mouseInside || _scrollViewFlags.mouseDownInScrollKnob || _horizontalScrollKnob.flashing);


### PR DESCRIPTION
Scroll indicators now show up while the scroll view is being dragged when the scroll indicator visibility setting is TUIScrollViewIndicatorVisibleWhenScrolling.

There is still a minor issue here.  If you have a lot of content in the scroll view and decide to flick several times, each time you flick the scroll knob disappears and reappears quickly at the beginning of the flick.  This seems to be caused by the mouse down event.  Not sure what the fix for this is.
