### PR TITLE
Suppress compiler warnings for NSLog string format

### DIFF
--- a/lib/UIKit/TUIFastIndexPath.m
+++ b/lib/UIKit/TUIFastIndexPath.m
@@ -85,7 +85,7 @@ static struct TUIFastIndexPath_staticStruct {
 
 - (NSString *)description
 {
-	return [NSString stringWithFormat:@"[%d,%d]", section, row];
+	return [NSString stringWithFormat:@"[%ld,%ld]", section, row];
 }
 
 - (NSUInteger)section

--- a/lib/UIKit/TUIView.m
+++ b/lib/UIKit/TUIView.m
@@ -454,7 +454,7 @@ else CGContextSetRGBFillColor(context, 1, 0, 0, 0.3); CGContextFillRect(context,
 	} else if(contentMode == TUIViewContentModeScaleAspectFill) {
 		_layer.contentsGravity = kCAGravityResizeAspectFill;
 	} else {
-		NSAssert1(NO, @"%lu is not a valid contentMode.", contentMode);
+		NSAssert1(NO, @"%ud is not a valid contentMode.", contentMode);
 	}
 }
 


### PR DESCRIPTION
Suppresses warnings from mis-matched string formatters.
